### PR TITLE
feat: implement authentication service and data models (#23)

### DIFF
--- a/KanbAI-Web/src/app/core/models/auth.models.ts
+++ b/KanbAI-Web/src/app/core/models/auth.models.ts
@@ -1,0 +1,21 @@
+﻿export interface LoginRequestDto {
+  email: string;
+  password?: string;
+}
+
+export interface RegisterRequestDto {
+  name: string;
+  email: string;
+  password?: string;
+}
+
+export interface UserProfileDto {
+  id: string;
+  name: string;
+  email: string;
+}
+
+export interface AuthResponseDto {
+  token: string;
+  user: UserProfileDto;
+}

--- a/KanbAI-Web/src/app/core/services/AuthService.ts
+++ b/KanbAI-Web/src/app/core/services/AuthService.ts
@@ -1,0 +1,32 @@
+﻿import {Injectable, inject, signal} from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable, tap } from 'rxjs';
+import { AuthResponseDto, UserProfileDto, LoginRequestDto, RegisterRequestDto } from '../models/auth.models';
+import { data } from 'autoprefixer';
+
+@Injectable({ providedIn: 'root' })
+export class AuthService {
+  private http = inject(HttpClient);
+
+  private readonly apiUrl = 'http://localhost:5257/api/auth';
+
+  currentUser = signal<UserProfileDto | null>(null);
+
+  login(credentials: LoginRequestDto): Observable<AuthResponseDto> {
+    return this.http.post<AuthResponseDto>(`${this.apiUrl}/login`, credentials).pipe(tap(response => this.handleAuthSuccess(response)));
+  }
+
+  register(user: RegisterRequestDto): Observable<AuthResponseDto> {
+    return this.http.post<AuthResponseDto>(`${this.apiUrl}/register`, data).pipe(tap(response => this.handleAuthSuccess(response)));
+  }
+
+  logout(): void {
+    localStorage.removeItem('jwt_token');
+    this.currentUser.set(null);
+  }
+
+  private handleAuthSuccess(response: AuthResponseDto): void {
+    localStorage.setItem('jwt_token', response.token);
+    this.currentUser.set(response.user);
+  }
+}

--- a/KanbAI-Web/src/app/core/services/auth-state.service.ts
+++ b/KanbAI-Web/src/app/core/services/auth-state.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, signal, computed } from '@angular/core';
+import { Injectable, signal, computed, inject } from '@angular/core';
 
 export interface AuthState {
   token: string | null;


### PR DESCRIPTION
Establishes the core authentication infrastructure by providing a service for handling user identity and persistence. This includes the definition of type-safe DTOs for login and registration flows.

- Created `AuthService` to manage login, registration, and logout HTTP requests
- Defined `LoginRequestDto`, `RegisterRequestDto`, and `AuthResponseDto` interfaces
- Integrated Angular Signals for reactive `currentUser` state tracking
- Implemented JWT token persistence using local storage

Fixes #23