### PR TITLE
feat: implement registration page UI and form validation (#25)

### DIFF
--- a/KanbAI-Web/src/app/app.routes.ts
+++ b/KanbAI-Web/src/app/app.routes.ts
@@ -5,16 +5,26 @@ import { unauthGuard } from './core/guards/unauth.guard';
 export const routes: Routes = [
   {
     path: '',
-    loadComponent: () => import('./features/landing/landing-page/landing-page.component').then(m => m.LandingPageComponent),
-    canActivate: [unauthGuard]
+    loadComponent: () =>
+      import('./features/landing/landing-page/landing-page.component').then(
+        (m) => m.LandingPageComponent,
+      ),
+    canActivate: [unauthGuard],
   },
   {
     path: 'login',
-    loadComponent: () => import('./features/auth/login-page/login-page.component').then(m => m.LoginPageComponent)
+    loadComponent: () =>
+      import('./features/auth/login-page/login-page.component').then((m) => m.LoginPageComponent),
+  },
+  {
+    path: 'register',
+    loadComponent: () =>
+      import('./features/auth/register-page/register-page.component').then((m) => m.RegisterPageComponent),
   },
   {
     path: 'board',
-    loadComponent: () => import('./features/board/board-page/board-page.component').then(m => m.BoardPageComponent),
-    canActivate: [authGuard]
-  }
+    loadComponent: () =>
+      import('./features/board/board-page/board-page.component').then((m) => m.BoardPageComponent),
+    canActivate: [authGuard],
+  },
 ];

--- a/KanbAI-Web/src/app/core/services/AuthService.ts
+++ b/KanbAI-Web/src/app/core/services/AuthService.ts
@@ -2,7 +2,6 @@
 import { HttpClient } from '@angular/common/http';
 import { Observable, tap } from 'rxjs';
 import { AuthResponseDto, UserProfileDto, LoginRequestDto, RegisterRequestDto } from '../models/auth.models';
-import { data } from 'autoprefixer';
 
 @Injectable({ providedIn: 'root' })
 export class AuthService {
@@ -17,7 +16,7 @@ export class AuthService {
   }
 
   register(user: RegisterRequestDto): Observable<AuthResponseDto> {
-    return this.http.post<AuthResponseDto>(`${this.apiUrl}/register`, data).pipe(tap(response => this.handleAuthSuccess(response)));
+    return this.http.post<AuthResponseDto>(`${this.apiUrl}/register`, user).pipe(tap(response => this.handleAuthSuccess(response)));
   }
 
   logout(): void {

--- a/KanbAI-Web/src/app/features/auth/login-page/login-page.component.html
+++ b/KanbAI-Web/src/app/features/auth/login-page/login-page.component.html
@@ -37,7 +37,7 @@
 
     <p class="text-center mt-6 text-sm text-text-tertiary">
       Don't have an account?
-      <a href="#" class="text-brand-primary font-medium hover:underline">Request access</a>
+      <a routerLink="/register" class="text-brand-primary font-medium hover:underline">Request Access</a>
     </p>
   </div>
 </div>

--- a/KanbAI-Web/src/app/features/auth/login-page/login-page.component.ts
+++ b/KanbAI-Web/src/app/features/auth/login-page/login-page.component.ts
@@ -7,7 +7,7 @@ import {
   Validators,
   FormControl,
 } from '@angular/forms';
-import { Router } from '@angular/router';
+import { Router, RouterLink } from '@angular/router';
 import { AuthService } from '../../../core/services/AuthService';
 import { FormCardComponent } from '../components/form-card/form-card.component';
 import { FormInputComponent } from '../components/form-input/form-input.component';
@@ -22,6 +22,7 @@ import { FormButtonComponent } from '../components/form-button/form-button.compo
     FormCardComponent,
     FormInputComponent,
     FormButtonComponent,
+    RouterLink,
   ],
   templateUrl: './login-page.component.html',
   styleUrl: './login-page.component.scss',
@@ -56,7 +57,7 @@ export class LoginPageComponent {
       this.authService.login(credentials).subscribe({
         next: (response) => {
           localStorage.setItem('access_token', response.token);
-          this.router.navigate(['/dashboard']);
+          this.router.navigate(['/']);
         },
         error: (err) => {
           console.error('Login failed', err);

--- a/KanbAI-Web/src/app/features/auth/register-page/register-page.component.html
+++ b/KanbAI-Web/src/app/features/auth/register-page/register-page.component.html
@@ -1,0 +1,63 @@
+﻿<div class="flex items-center justify-center min-h-screen bg-background-sidebarLight font-sans">
+  <div class="w-full max-w-[400px] px-4">
+
+    <div class="text-center mb-8">
+      <h1 class="text-xxl font-bold text-text-primary tracking-tight">Create Account</h1>
+      <p class="text-sm text-text-secondary mt-2">Join our Kanban board and start managing tasks</p>
+    </div>
+
+    <app-form-card>
+      <form [formGroup]="registerForm" (ngSubmit)="onSubmit()" class="flex flex-col gap-5">
+
+        <app-form-input
+          label="Full Name"
+          type="text"
+          placeholder="e.g. Alex Doe"
+          [control]="nameControl">
+        </app-form-input>
+
+        <app-form-input
+          label="Email Address"
+          type="email"
+          placeholder="e.g. alex@company.com"
+          [control]="emailControl">
+        </app-form-input>
+
+        <app-form-input
+          label="Password"
+          type="password"
+          placeholder="Min. 8 characters"
+          [control]="passwordControl">
+        </app-form-input>
+
+        <app-form-input
+          label="Confirm Password"
+          type="password"
+          placeholder="Repeat your password"
+          [control]="confirmPasswordControl">
+        </app-form-input>
+
+        @if (registerForm.errors?.['passwordMismatch'] && confirmPasswordControl.touched) {
+          <span class="text-xs text-status-high -mt-3">
+            Passwords do not match.
+          </span>
+        }
+
+        <div class="mt-2">
+          <app-form-button
+            type="submit"
+            [fullWidth]="true"
+            [disabled]="registerForm.invalid || isLoading">
+            {{ isLoading ? 'Creating Account...' : 'Register' }}
+          </app-form-button>
+        </div>
+
+      </form>
+    </app-form-card>
+
+    <p class="text-center mt-6 text-sm text-text-tertiary">
+      Already have an account?
+      <a routerLink="/login" class="text-brand-primary font-medium hover:underline">Sign In</a>
+    </p>
+  </div>
+</div>

--- a/KanbAI-Web/src/app/features/auth/register-page/register-page.component.ts
+++ b/KanbAI-Web/src/app/features/auth/register-page/register-page.component.ts
@@ -1,0 +1,81 @@
+﻿import { Component, ChangeDetectionStrategy, inject } from '@angular/core';
+import {
+  FormBuilder,
+  FormGroup,
+  ReactiveFormsModule,
+  Validators,
+  FormControl,
+} from '@angular/forms';
+import { Router, RouterModule } from '@angular/router';
+import { FormCardComponent } from '../components/form-card/form-card.component';
+import { FormInputComponent } from '../components/form-input/form-input.component';
+import { FormButtonComponent } from '../components/form-button/form-button.component';
+import { AuthService } from '../../../core/services/AuthService';
+import { passwordMatchValidator } from '../validator/password-match.validator';
+
+@Component({
+  selector: 'app-register-page',
+  standalone: true,
+  imports: [
+    ReactiveFormsModule,
+    RouterModule,
+    FormCardComponent,
+    FormInputComponent,
+    FormButtonComponent,
+  ],
+  templateUrl: './register-page.component.html',
+  styleUrl: './register-page.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class RegisterPageComponent {
+  private fb = inject(FormBuilder);
+  private authService = inject(AuthService);
+  private router = inject(Router);
+
+  public registerForm: FormGroup = this.fb.group(
+    {
+      name: ['', [Validators.required]],
+      email: ['', [Validators.required, Validators.email]],
+      password: ['', [Validators.required, Validators.minLength(8)]],
+      confirmPassword: ['', [Validators.required]],
+    },
+    { validators: passwordMatchValidator },
+  );
+
+  public isLoading: boolean = false;
+
+  get nameControl() {
+    return this.registerForm.get('name') as FormControl;
+  }
+  get emailControl() {
+    return this.registerForm.get('email') as FormControl;
+  }
+  get passwordControl() {
+    return this.registerForm.get('password') as FormControl;
+  }
+  get confirmPasswordControl() {
+    return this.registerForm.get('confirmPassword') as FormControl;
+  }
+
+  onSubmit(): void {
+    if (this.registerForm.valid) {
+      this.isLoading = true;
+      const { name, email, password } = this.registerForm.value;
+
+      this.authService.register({ name, email, password }).subscribe({
+        next: () => {
+          this.router.navigate(['/login']);
+        },
+        error: (err) => {
+          console.error('Registration failed', err);
+          this.isLoading = false;
+        },
+        complete: () => {
+          this.isLoading = false;
+        },
+      });
+    } else {
+      this.registerForm.markAllAsTouched();
+    }
+  }
+}

--- a/KanbAI-Web/src/app/features/auth/validator/password-match.validator.ts
+++ b/KanbAI-Web/src/app/features/auth/validator/password-match.validator.ts
@@ -1,0 +1,12 @@
+﻿import { AbstractControl, ValidationErrors, ValidatorFn } from '@angular/forms';
+
+export const passwordMatchValidator: ValidatorFn = (
+  control: AbstractControl,
+): ValidationErrors | null => {
+  const password = control.get('password');
+  const confirmPassword = control.get('confirmPassword');
+
+  return password && confirmPassword && password.value !== confirmPassword.value
+    ? { passwordMismatch: true }
+    : null;
+};

--- a/KanbAI-Web/src/app/features/landing/landing-page/landing-page.component.ts
+++ b/KanbAI-Web/src/app/features/landing/landing-page/landing-page.component.ts
@@ -48,7 +48,6 @@ export class LandingPageComponent {
   }
 
   onSignUpClick(): void {
-    // Route doesn't exist yet, navigate to login with query param or show message
-    this.router.navigate(['/login'], { queryParams: { mode: 'register' } });
+    this.router.navigate(['/register'], { queryParams: { mode: 'register' } });
   }
 }


### PR DESCRIPTION
Establishes the user registration interface by implementing a reactive form with custom validation and integrating it into the application routing.

- Created `RegisterPageComponent` with fields for name, email, and password confirmation
- Implemented `passwordMatchValidator` to ensure password consistency
- Added the registration route and updated navigation links across landing and login pages
- Fixed a bug in `AuthService` where the registration payload was incorrectly referenced
- Corrected post-login navigation to redirect to the home path

Fixes #25