### PR TITLE
feat: implement JWT HTTP interceptor for API authentication (#26)

### DIFF
--- a/KanbAI-Web/src/app/core/interceptors/auth.interceptor.ts
+++ b/KanbAI-Web/src/app/core/interceptors/auth.interceptor.ts
@@ -1,5 +1,9 @@
-import { HttpInterceptorFn } from '@angular/common/http';
+import { HttpInterceptorFn, HttpErrorResponse } from '@angular/common/http';
 import { environment } from '../../../environments/environment';
+import { inject } from '@angular/core';
+import { Router } from '@angular/router';
+import { catchError, throwError } from 'rxjs';
+import { AuthService } from '../services/AuthService';
 
 /**
  * Authentication Interceptor
@@ -8,34 +12,32 @@ import { environment } from '../../../environments/environment';
  * 1. Attach JWT tokens to outgoing requests
  * 2. Handle 401/403 authentication errors globally
  * 3. Redirect to login on authentication failures
- *
- * Current behavior: Pass-through (no modifications)
  */
 export const authInterceptor: HttpInterceptorFn = (req, next) => {
+  const router = inject(Router);
+  const authService = inject(AuthService);
+
   // Only intercept requests to our API (not external APIs)
   if (req.url.startsWith(environment.apiUrl)) {
-    // TODO: Attach JWT token from storage
-    // const token = localStorage.getItem('auth_token');
-    // if (token) {
-    //   req = req.clone({
-    //     setHeaders: {
-    //       Authorization: `Bearer ${token}`
-    //     }
-    //   });
-    // }
+    const token = localStorage.getItem('jwt_token');
+
+    if (token) {
+      req = req.clone({
+        setHeaders: {
+          Authorization: `Bearer ${token}`
+        }
+      });
+    }
   }
 
-  // Pass the request through to the next handler
-  return next(req);
+  return next(req).pipe(
+    catchError((error: HttpErrorResponse) => {
+      if (error.status === 401) {
+        authService.logout();
+        router.navigate(['/login']);
+      }
 
-  // TODO: Add error handling for 401/403/500 responses
-  // Example future implementation:
-  // return next(req).pipe(
-  //   catchError((error: HttpErrorResponse) => {
-  //     if (error.status === 401) {
-  //       // Redirect to login or dispatch logout action
-  //     }
-  //     return throwError(() => error);
-  //   })
-  // );
+      return throwError(() => error);
+    })
+  );
 };


### PR DESCRIPTION
Establishes a mechanism to automatically attach authentication tokens to API requests and handle unauthorized responses globally.

- Configured the interceptor to attach JWT tokens from local storage to outgoing requests targeting the internal API
- Implemented global 401 error handling to trigger a logout and redirect users to the login page
- Added logic to ensure interception only applies to requests defined in the environment API URL

Fixes #26