### PR TITLE
feat: integrate real-time events with state management (#46)

### DIFF
--- a/.claude/backend_api_map.md
+++ b/.claude/backend_api_map.md
@@ -9,6 +9,7 @@ This document describes HTTP routes exposed by `KanbAI-Core`, request/response s
 | Scheme | JWT Bearer (`Authorization: Bearer <token>`) |
 | User identity | Controllers read `ClaimTypes.NameIdentifier` as `Guid` |
 | Anonymous | Health check; auth register/login |
+| SignalR | Browser WebSocket connections may pass the JWT as `?access_token=<jwt>` query string on requests to `/hubs/*` (handled by `JwtBearerEvents.OnMessageReceived` in `Program.cs`). |
 
 Endpoints marked **JWT** require a valid Bearer token.
 
@@ -93,6 +94,40 @@ Factories in code: `ApiResponse.Ok(...)`, `ApiResponse<T>.Ok(data, ...)`, `ApiRe
 **Create task** failures (examples): `404` column not found; `403` not a project member; `400` missing title, assignee not found, or assignee not a member.
 
 **Move task** failures (examples): `404` task or target column; `403` not a member; `400` cross-project move or invalid `taskOrder`.
+
+---
+
+## Real-time updates (SignalR)
+
+A SignalR hub is exposed at `/hubs/kanban` and is used by the backend to push board updates to connected clients. Authentication is required (JWT Bearer, or `?access_token=<jwt>` query string for browsers).
+
+### Hub methods (client → server)
+
+| Method | Parameters | Behaviour | Errors |
+|--------|------------|-----------|--------|
+| `JoinProjectGroup` | `projectId: string` (Guid) | Adds the current connection to the group `project_{projectId lowercase}` so it receives that project's broadcasts. | `HubException "Project ID is required."` on null/empty; `HubException "Invalid project ID format."` on non-Guid input. |
+| `LeaveProjectGroup` | `projectId: string` (Guid) | Removes the connection from the project's group. | Same as above. |
+
+The hub does **not** verify project membership on `JoinProjectGroup` — server-side authorization is enforced at the HTTP layer where the mutations happen, and broadcasts are only emitted after a successful mutation. Clients should call `LeaveProjectGroup` when navigating away from a board. SignalR cleans up group memberships automatically on disconnect.
+
+### Server-sent events (server → client)
+
+All events are broadcast to the group `project_{projectId lowercase}`. Payloads use camelCase property names (default ASP.NET Core JSON serialization).
+
+| Event name | Triggered by | Payload |
+|------------|--------------|---------|
+| `ProjectUpdated` | `PUT /api/project/{id}` | `ProjectUpdatedEventDto` |
+| `ProjectDeleted` | `DELETE /api/project/{id}` | `ProjectDeletedEventDto` |
+| `MemberAdded` | `POST /api/project/{projectId}/members` | `MemberResponseDto` |
+| `MemberRemoved` | `DELETE /api/project/{projectId}/members/{userId}` | `MemberRemovedEventDto` |
+| `ColumnCreated` | `POST /api/column/project/{projectId}` | `ColumnResponseDto` |
+| `ColumnDeleted` | `DELETE /api/column/{id}` | `ColumnDeletedEventDto` |
+| `TaskCreated` | `POST /api/task/column/{columnId}` | `TaskResponseDto` |
+| `TaskMoved` | `PUT /api/task/{taskId}/move` | `TaskMovedEventDto` |
+
+Broadcasts happen after the EF Core `SaveChangesAsync` succeeds. Broadcast failures are logged but do not fail the originating HTTP request — the mutation is the source of truth, the broadcast is best-effort notification.
+
+> ⚠️ **Not yet broadcast:** `ProjectCreated` (no group exists at creation time), and no task-update/task-delete events exist yet because those endpoints are not implemented. Clients relying on `GET /api/project` after page load will still reflect new projects.
 
 ---
 
@@ -227,6 +262,50 @@ The frontend Members UI (issue #33) sends `{ email }` only.
 | `columnId` | `string` (GUID) | Required — target column |
 | `taskOrder` | `number` | Required, ≥ 0 |
 
+### SignalR event DTOs
+
+**`ProjectUpdatedEventDto`**
+
+| JSON property | Type | Notes |
+|---------------|------|--------|
+| `projectId` | `string` (GUID) | |
+| `name` | `string` | |
+| `description` | `string \| null` | |
+| `updatedAt` | `string` (ISO 8601) | |
+
+**`ProjectDeletedEventDto`**
+
+| JSON property | Type | Notes |
+|---------------|------|--------|
+| `projectId` | `string` (GUID) | |
+
+**`MemberRemovedEventDto`**
+
+| JSON property | Type | Notes |
+|---------------|------|--------|
+| `userId` | `string` (GUID) | |
+| `projectId` | `string` (GUID) | |
+
+**`ColumnDeletedEventDto`**
+
+| JSON property | Type | Notes |
+|---------------|------|--------|
+| `columnId` | `string` (GUID) | |
+| `projectId` | `string` (GUID) | |
+
+**`TaskMovedEventDto`**
+
+| JSON property | Type | Notes |
+|---------------|------|--------|
+| `taskId` | `string` (GUID) | |
+| `oldColumnId` | `string` (GUID) | Column the task was in before the move |
+| `newColumnId` | `string` (GUID) | Column the task is in after the move |
+| `oldTaskOrder` | `number` | Previous order index |
+| `newTaskOrder` | `number` | New order index |
+| `task` | `TaskResponseDto` | Full post-move task state |
+
+The `MemberAdded`, `ColumnCreated`, and `TaskCreated` events send the corresponding response DTO (`MemberResponseDto`, `ColumnResponseDto`, `TaskResponseDto`) directly as the payload — no event-specific wrapper.
+
 ---
 
 ## Source locations
@@ -235,6 +314,7 @@ The frontend Members UI (issue #33) sends `{ email }` only.
 |------|------|
 | Controllers | `KanbAI-Core/KanbAI-Core/Controllers/` |
 | DTOs | `KanbAI-Core/KanbAI-Core/DTOs/` |
+| SignalR hub | `KanbAI-Core/KanbAI-Core/Hubs/KanbanHub.cs` |
 
 ---
 
@@ -254,4 +334,6 @@ Pairing this backend map with a few frontend-focused docs keeps UI work aligned 
 
 6. **Optional: OpenAPI-driven types** — If you generate TypeScript clients from the OpenAPI doc (`MapOpenApi` in Development), document the generation command and where generated files live.
 
-Together with **`backend_api_map.md`**, these give frontend developers enough context to implement safely without rediscovering quirks (especially the auth response shape vs `ApiResponse`).
+7. **SignalR integration notes** — How the SPA opens the `/hubs/kanban` connection (including passing the JWT via `?access_token` for browser WebSockets), when to call `JoinProjectGroup` / `LeaveProjectGroup`, and how each event (`TaskMoved`, `ColumnDeleted`, etc.) maps to local state reconciliation.
+
+Together with **`backend_api_map.md`**, these give frontend developers enough context to implement safely without rediscovering quirks (especially the auth response shape vs `ApiResponse` and the real-time event contracts).

--- a/KanbAI-Web/src/app/app.routes.spec.ts
+++ b/KanbAI-Web/src/app/app.routes.spec.ts
@@ -39,8 +39,8 @@ describe('App Routing', () => {
       expect(loginRoute?.loadComponent).toBeDefined();
     });
 
-    it('should define board route', () => {
-      const boardRoute = routes.find(r => r.path === 'board');
+    it('should define parameterized board route', () => {
+      const boardRoute = routes.find(r => r.path === 'board/:projectId');
       expect(boardRoute).toBeTruthy();
       expect(boardRoute?.loadComponent).toBeDefined();
     });
@@ -70,10 +70,10 @@ describe('App Routing', () => {
       expect(location.path()).toBe('/login');
     });
 
-    it('should redirect /board to /login with returnUrl when unauthenticated (authGuard)', async () => {
-      await router.navigate(['/board']);
+    it('should redirect /board/:projectId to /login with returnUrl when unauthenticated (authGuard)', async () => {
+      await router.navigate(['/board/proj-1']);
       // authGuard redirects to /login and preserves the attempted URL.
-      expect(location.path()).toBe('/login?returnUrl=%2Fboard');
+      expect(location.path()).toBe('/login?returnUrl=%2Fboard%2Fproj-1');
     });
 
     it('should navigate from login to board when guard allows', async () => {
@@ -82,14 +82,14 @@ describe('App Routing', () => {
 
       // Note: This test would need authStateService.setAuthState() to pass authGuard
       // For now, it will redirect to /login due to authGuard (with returnUrl preserved)
-      await router.navigate(['/board']);
-      expect(location.path()).toBe('/login?returnUrl=%2Fboard');
+      await router.navigate(['/board/proj-1']);
+      expect(location.path()).toBe('/login?returnUrl=%2Fboard%2Fproj-1');
     });
 
     it('should navigate from board to login', async () => {
-      // When unauthenticated, /board redirects to /login with returnUrl
-      await router.navigate(['/board']);
-      expect(location.path()).toBe('/login?returnUrl=%2Fboard');
+      // When unauthenticated, /board/:projectId redirects to /login with returnUrl
+      await router.navigate(['/board/proj-1']);
+      expect(location.path()).toBe('/login?returnUrl=%2Fboard%2Fproj-1');
 
       await router.navigate(['/login']);
       expect(location.path()).toBe('/login');
@@ -113,7 +113,7 @@ describe('App Routing', () => {
     });
 
     it('should lazy load BoardPageComponent', async () => {
-      const boardRoute = routes.find(r => r.path === 'board');
+      const boardRoute = routes.find(r => r.path === 'board/:projectId');
       expect(boardRoute?.loadComponent).toBeDefined();
 
       if (boardRoute?.loadComponent) {
@@ -142,7 +142,7 @@ describe('App Routing', () => {
 
     it('should handle rapid route switching', async () => {
       await router.navigate(['/login']);
-      await router.navigate(['/board']);
+      await router.navigate(['/board/proj-1']);
       await router.navigate(['/login']);
       // After the final explicit navigate to '/login', the returnUrl from the
       // prior /board redirect is cleared because we navigated to /login directly.

--- a/KanbAI-Web/src/app/app.routes.ts
+++ b/KanbAI-Web/src/app/app.routes.ts
@@ -28,7 +28,7 @@ export const routes: Routes = [
     canActivate: [authGuard]
   },
   {
-    path: 'board',
+    path: 'board/:projectId',
     loadComponent: () =>
       import('./features/board/board-page/board-page.component').then(m => m.BoardPageComponent),
     canActivate: [authGuard]

--- a/KanbAI-Web/src/app/core/constants/auth-routes.spec.ts
+++ b/KanbAI-Web/src/app/core/constants/auth-routes.spec.ts
@@ -36,9 +36,11 @@ describe('auth-routes constants', () => {
       expect(PROTECTED_PATHS).toContain('dashboard');
     });
 
-    it('retains "board" so the legacy route keeps its guard coverage', () => {
-      // The tech spec (Q3) preserves /board to avoid churning pre-existing tests.
-      expect(PROTECTED_PATHS).toContain('board');
+    it('includes the parameterized board route "board/:projectId" for guard coverage', () => {
+      // Issue #46 replaces the legacy `/board` shell route with
+      // `/board/:projectId` so BoardPageComponent can read the project id
+      // for JoinProjectGroup / LeaveProjectGroup. Guard coverage moves with it.
+      expect(PROTECTED_PATHS).toContain('board/:projectId');
     });
 
     it('stores bare path segments (no leading slash) so routes.find(r => r.path === p) works', () => {

--- a/KanbAI-Web/src/app/core/constants/auth-routes.ts
+++ b/KanbAI-Web/src/app/core/constants/auth-routes.ts
@@ -38,7 +38,7 @@ export const REGISTER_ROUTE = '/register';
  *
  * Add new authenticated routes here as they land (e.g., `/dashboard`).
  */
-export const PROTECTED_PATHS: readonly string[] = ['board', 'dashboard'];
+export const PROTECTED_PATHS: readonly string[] = ['board/:projectId', 'dashboard'];
 
 /**
  * Paths that MUST be protected by `unauthGuard` (visible to anonymous

--- a/KanbAI-Web/src/app/core/models/realtime-events.ts
+++ b/KanbAI-Web/src/app/core/models/realtime-events.ts
@@ -1,0 +1,123 @@
+/**
+ * Typed DTOs for server-sent SignalR events broadcast by KanbAI-Core on the
+ * `/hubs/kanban` hub. Payloads mirror the backend event DTOs (camelCase JSON,
+ * nullable fields preserved, ISO-8601 timestamps as `string`).
+ *
+ * See `.claude/backend_api_map.md` §"Server-sent events" for the authoritative
+ * name/payload list.
+ */
+
+/**
+ * String-literal constants for every server-sent event name. Used by
+ * subscribers (`SignalRService.on<T>(REALTIME_EVENT.ProjectUpdated)`) as a
+ * single source of truth so a typo cannot drift between the publisher side
+ * (backend DTO name) and the subscriber side.
+ */
+export const REALTIME_EVENT = {
+  ProjectUpdated: 'ProjectUpdated',
+  ProjectDeleted: 'ProjectDeleted',
+  MemberAdded: 'MemberAdded',
+  MemberRemoved: 'MemberRemoved',
+  ColumnCreated: 'ColumnCreated',
+  ColumnDeleted: 'ColumnDeleted',
+  TaskCreated: 'TaskCreated',
+  TaskMoved: 'TaskMoved'
+} as const;
+
+export type RealtimeEventName = typeof REALTIME_EVENT[keyof typeof REALTIME_EVENT];
+
+/** Payload of `ProjectUpdated`, emitted by `PUT /api/project/{id}`. */
+export interface ProjectUpdatedEvent {
+  projectId: string;
+  name: string;
+  description: string | null;
+  updatedAt: string; // ISO-8601
+}
+
+/** Payload of `ProjectDeleted`, emitted by `DELETE /api/project/{id}`. */
+export interface ProjectDeletedEvent {
+  projectId: string;
+}
+
+/**
+ * Payload of `MemberAdded`, emitted by `POST /api/project/{projectId}/members`.
+ *
+ * ⚠ BACKEND CAVEAT: the server broadcasts the raw `MemberResponseDto` — there
+ * is no `projectId` on the wire. Attribution is done via the "current dialog
+ * context" held by `MembersStateService.currentProjectContext`. See
+ * `issue_46_tech_spec.md` §"Known Backend Contract Caveats" for the
+ * follow-up backend ticket.
+ */
+export interface MemberAddedEvent {
+  userId: string;
+  name: string;
+  email: string;
+  role: string;
+  joinedAt: string; // ISO-8601
+}
+
+/**
+ * Payload of `MemberRemoved`, emitted by
+ * `DELETE /api/project/{projectId}/members/{userId}`. Carries `projectId`.
+ */
+export interface MemberRemovedEvent {
+  userId: string;
+  projectId: string;
+}
+
+/**
+ * Payload of `ColumnCreated`, emitted by
+ * `POST /api/column/project/{projectId}`. Carries `projectId` directly.
+ */
+export interface ColumnCreatedEvent {
+  id: string;
+  name: string;
+  colorCode: string | null;
+  columnOrder: number;
+  projectId: string;
+  createdAt: string; // ISO-8601
+  updatedAt: string; // ISO-8601
+}
+
+/**
+ * Payload of `ColumnDeleted`, emitted by `DELETE /api/column/{id}`.
+ * Carries `projectId` directly.
+ */
+export interface ColumnDeletedEvent {
+  columnId: string;
+  projectId: string;
+}
+
+/**
+ * Payload of `TaskCreated`, emitted by `POST /api/task/column/{columnId}`.
+ *
+ * ⚠ BACKEND CAVEAT: the server broadcasts the raw `TaskResponseDto` — there
+ * is no `projectId` on the wire. Attribution is done via
+ * `BoardStateService.currentProjectId` plus the fact that the client only
+ * receives events from project groups it has joined.
+ */
+export interface TaskCreatedEvent {
+  id: string;
+  title: string;
+  content: string | null;
+  taskOrder: number;
+  columnId: string;
+  assignedId: string | null;
+  createdAt: string; // ISO-8601
+  updatedAt: string; // ISO-8601
+}
+
+/**
+ * Payload of `TaskMoved`, emitted by `PUT /api/task/{taskId}/move`.
+ * Includes the full post-move task DTO so the subscriber can rebuild
+ * bucket state without a round-trip.
+ */
+export interface TaskMovedEvent {
+  taskId: string;
+  oldColumnId: string;
+  newColumnId: string;
+  oldTaskOrder: number;
+  newTaskOrder: number;
+  /** Full post-move `TaskResponseDto`. */
+  task: TaskCreatedEvent;
+}

--- a/KanbAI-Web/src/app/core/services/signalr.service.spec.ts
+++ b/KanbAI-Web/src/app/core/services/signalr.service.spec.ts
@@ -17,6 +17,7 @@ const mocks = vi.hoisted(() => {
     start: ReturnType<typeof vi.fn>;
     stop: ReturnType<typeof vi.fn>;
     on: ReturnType<typeof vi.fn>;
+    invoke: ReturnType<typeof vi.fn>;
     onreconnecting: ReturnType<typeof vi.fn>;
     onreconnected: ReturnType<typeof vi.fn>;
     onclose: ReturnType<typeof vi.fn>;
@@ -44,6 +45,7 @@ const mocks = vi.hoisted(() => {
       on: vi.fn((name: string, handler: (payload: unknown) => void) => {
         handlers.set(name, handler);
       }),
+      invoke: vi.fn().mockResolvedValue(undefined),
       onreconnecting: vi.fn((cb: (...args: unknown[]) => void) => {
         conn._onreconnecting = cb;
       }),
@@ -646,6 +648,149 @@ describe('SignalRService', () => {
       }
 
       // (beforeEach of the next test restores the default build factory.)
+      consoleErrorSpy.mockRestore();
+      consoleLogSpy.mockRestore();
+    });
+  });
+
+  describe('joinProjectGroup() / leaveProjectGroup()', () => {
+    const PROJECT_ID = 'proj-abc-123';
+
+    it('invokes the underlying hub method once connected', async () => {
+      const auth = createAuthStub({ authenticated: true, token: 'fake-token' });
+      TestBed.configureTestingModule({
+        providers: [
+          SignalRService,
+          { provide: AuthStateService, useValue: auth }
+        ]
+      });
+
+      const service = TestBed.inject(SignalRService);
+      TestBed.flushEffects();
+      await flushMicrotasks();
+      await flushMicrotasks();
+      expect(service.connectionState()).toBe('connected');
+
+      const connection = mocks.state.latestBuilder!._connection;
+      await service.joinProjectGroup(PROJECT_ID);
+      await service.leaveProjectGroup(PROJECT_ID);
+
+      expect(connection.invoke).toHaveBeenCalledWith('JoinProjectGroup', PROJECT_ID);
+      expect(connection.invoke).toHaveBeenCalledWith('LeaveProjectGroup', PROJECT_ID);
+      expect(connection.invoke).toHaveBeenCalledTimes(2);
+    });
+
+    it('is a no-op when the connection is not yet connected', async () => {
+      const auth = createAuthStub({ authenticated: false, token: null });
+      TestBed.configureTestingModule({
+        providers: [
+          SignalRService,
+          { provide: AuthStateService, useValue: auth }
+        ]
+      });
+
+      const service = TestBed.inject(SignalRService);
+      TestBed.flushEffects();
+
+      await expect(service.joinProjectGroup(PROJECT_ID)).resolves.toBeUndefined();
+      await expect(service.leaveProjectGroup(PROJECT_ID)).resolves.toBeUndefined();
+
+      // No connection was ever built, so there is no invoke to spy on.
+      expect(mocks.state.builderCount).toBe(0);
+    });
+
+    it('is a no-op after auth drops to disconnected', async () => {
+      const auth = createAuthStub({ authenticated: true, token: 'fake-token' });
+      TestBed.configureTestingModule({
+        providers: [
+          SignalRService,
+          { provide: AuthStateService, useValue: auth }
+        ]
+      });
+
+      const service = TestBed.inject(SignalRService);
+      TestBed.flushEffects();
+      await flushMicrotasks();
+      await flushMicrotasks();
+
+      const connection = mocks.state.latestBuilder!._connection;
+
+      // Stop the connection (simulating logout).
+      auth._setAuthenticated(false);
+      auth._setToken(null);
+      TestBed.flushEffects();
+      await flushMicrotasks();
+      await flushMicrotasks();
+      expect(service.connectionState()).toBe('disconnected');
+
+      await service.joinProjectGroup(PROJECT_ID);
+      await service.leaveProjectGroup(PROJECT_ID);
+
+      // Stop was called, but no Join/Leave invocation ever reached the wire.
+      expect(connection.invoke).not.toHaveBeenCalled();
+    });
+
+    it('is a no-op when projectId is empty/whitespace', async () => {
+      const auth = createAuthStub({ authenticated: true, token: 'fake-token' });
+      TestBed.configureTestingModule({
+        providers: [
+          SignalRService,
+          { provide: AuthStateService, useValue: auth }
+        ]
+      });
+
+      const service = TestBed.inject(SignalRService);
+      TestBed.flushEffects();
+      await flushMicrotasks();
+      await flushMicrotasks();
+
+      await service.joinProjectGroup('');
+      await service.joinProjectGroup('   ');
+      await service.leaveProjectGroup('');
+
+      const connection = mocks.state.latestBuilder!._connection;
+      expect(connection.invoke).not.toHaveBeenCalled();
+    });
+
+    it('logs a bare error and never throws when the hub invoke rejects, and never logs the projectId', async () => {
+      const auth = createAuthStub({ authenticated: true, token: 'fake-token' });
+      TestBed.configureTestingModule({
+        providers: [
+          SignalRService,
+          { provide: AuthStateService, useValue: auth }
+        ]
+      });
+
+      const service = TestBed.inject(SignalRService);
+      TestBed.flushEffects();
+      await flushMicrotasks();
+      await flushMicrotasks();
+
+      const connection = mocks.state.latestBuilder!._connection;
+      // Reject with an error whose message contains the projectId — the
+      // service must NOT propagate that to any console sink.
+      connection.invoke = vi
+        .fn()
+        .mockRejectedValue(new Error(`boom: ${PROJECT_ID}`));
+
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+      const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+      // Never throws.
+      await expect(service.joinProjectGroup(PROJECT_ID)).resolves.toBeUndefined();
+      await expect(service.leaveProjectGroup(PROJECT_ID)).resolves.toBeUndefined();
+
+      // Both hub methods logged once each; neither log contains the id.
+      expect(consoleErrorSpy).toHaveBeenCalled();
+      const allArgs = [
+        ...consoleErrorSpy.mock.calls.flat(),
+        ...consoleLogSpy.mock.calls.flat()
+      ];
+      for (const arg of allArgs) {
+        const asString = typeof arg === 'string' ? arg : JSON.stringify(arg);
+        expect(asString).not.toContain(PROJECT_ID);
+      }
+
       consoleErrorSpy.mockRestore();
       consoleLogSpy.mockRestore();
     });

--- a/KanbAI-Web/src/app/core/services/signalr.service.ts
+++ b/KanbAI-Web/src/app/core/services/signalr.service.ts
@@ -30,6 +30,24 @@ export interface SignalRServiceContract {
   start(): Promise<void>;
   stop(): Promise<void>;
   on<T>(eventName: string): Observable<T>;
+
+  /**
+   * Invokes the server hub method `JoinProjectGroup(projectId)` once the
+   * connection is `'connected'`. If called while not connected, the call is
+   * a no-op — the caller's connection-state effect is expected to re-trigger
+   * the join when the transport next reaches `'connected'`.
+   *
+   * Errors from the underlying `connection.invoke` (e.g. backend throws
+   * `HubException` on malformed id) are caught and a bare message is written
+   * via `console.error`; no payload fields are logged. The returned Promise
+   * never rejects, so `await`ing it never throws.
+   */
+  joinProjectGroup(projectId: string): Promise<void>;
+
+  /**
+   * Inverse of {@link joinProjectGroup}. Same error-handling contract.
+   */
+  leaveProjectGroup(projectId: string): Promise<void>;
 }
 
 @Injectable({ providedIn: 'root' })
@@ -148,5 +166,45 @@ export class SignalRService implements SignalRServiceContract {
     }
 
     return (subject as Subject<T>).asObservable();
+  }
+
+  async joinProjectGroup(projectId: string): Promise<void> {
+    await this.invokeGroupMethod('JoinProjectGroup', projectId);
+  }
+
+  async leaveProjectGroup(projectId: string): Promise<void> {
+    await this.invokeGroupMethod('LeaveProjectGroup', projectId);
+  }
+
+  /**
+   * Shared implementation for `JoinProjectGroup` / `LeaveProjectGroup`.
+   *
+   * - Silently drops empty/whitespace project ids so the backend's
+   *   `HubException "Project ID is required."` is never provoked by a
+   *   caller bug.
+   * - No-ops when the connection is not yet `'connected'`; the
+   *   connection-state effect in state-service consumers re-invokes on
+   *   reconnect, so there is no need to queue here.
+   * - Writes a bare error message to `console.error` on invoke failure —
+   *   never includes the projectId, token, or any payload field.
+   */
+  private async invokeGroupMethod(
+    hubMethod: 'JoinProjectGroup' | 'LeaveProjectGroup',
+    projectId: string
+  ): Promise<void> {
+    if (typeof projectId !== 'string' || projectId.trim().length === 0) {
+      return;
+    }
+
+    const connection = this.connection;
+    if (!connection || this.state() !== 'connected') {
+      return;
+    }
+
+    try {
+      await connection.invoke(hubMethod, projectId);
+    } catch {
+      console.error(`SignalR ${hubMethod} failed`);
+    }
   }
 }

--- a/KanbAI-Web/src/app/features/board/board-page/board-page.component.spec.ts
+++ b/KanbAI-Web/src/app/features/board/board-page/board-page.component.spec.ts
@@ -1,18 +1,62 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
+import { ActivatedRoute, convertToParamMap } from '@angular/router';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
 import { BoardPageComponent } from './board-page.component';
+import { BoardStateService } from '../state/board-state.service';
+
+interface BoardStateMock {
+  enterBoard: ReturnType<typeof vi.fn>;
+  leaveBoard: ReturnType<typeof vi.fn>;
+}
+
+function createMockBoardState(): BoardStateMock {
+  return {
+    enterBoard: vi.fn(),
+    leaveBoard: vi.fn()
+  };
+}
+
+function createFakeActivatedRoute(projectId: string | null): ActivatedRoute {
+  const paramMap = convertToParamMap(projectId === null ? {} : { projectId });
+  return {
+    snapshot: {
+      paramMap
+    }
+  } as unknown as ActivatedRoute;
+}
+
+async function mountBoard(
+  projectId: string | null = 'p-1'
+): Promise<{
+  fixture: ComponentFixture<BoardPageComponent>;
+  component: BoardPageComponent;
+  boardState: BoardStateMock;
+}> {
+  TestBed.resetTestingModule();
+  const boardState = createMockBoardState();
+  await TestBed.configureTestingModule({
+    imports: [BoardPageComponent],
+    providers: [
+      { provide: ActivatedRoute, useValue: createFakeActivatedRoute(projectId) },
+      { provide: BoardStateService, useValue: boardState }
+    ]
+  }).compileComponents();
+  const fixture = TestBed.createComponent(BoardPageComponent);
+  return { fixture, component: fixture.componentInstance, boardState };
+}
 
 describe('BoardPageComponent', () => {
-  let component: BoardPageComponent;
   let fixture: ComponentFixture<BoardPageComponent>;
+  let component: BoardPageComponent;
+  let boardState: BoardStateMock;
 
   beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [BoardPageComponent]
-    }).compileComponents();
-
-    fixture = TestBed.createComponent(BoardPageComponent);
-    component = fixture.componentInstance;
+    const mounted = await mountBoard('p-1');
+    fixture = mounted.fixture;
+    component = mounted.component;
+    boardState = mounted.boardState;
   });
 
   describe('Component Creation', () => {
@@ -21,7 +65,33 @@ describe('BoardPageComponent', () => {
     });
   });
 
-  describe('Rendering', () => {
+  describe('Lifecycle — Join/Leave via BoardStateService', () => {
+    it('calls enterBoard(projectId) in ngOnInit', () => {
+      fixture.detectChanges();
+      expect(boardState.enterBoard).toHaveBeenCalledWith('p-1');
+      expect(boardState.enterBoard).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls leaveBoard() in ngOnDestroy', () => {
+      fixture.detectChanges();
+      fixture.destroy();
+      expect(boardState.leaveBoard).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not call enterBoard when the projectId param is absent', async () => {
+      const mounted = await mountBoard(null);
+      mounted.fixture.detectChanges();
+      expect(mounted.boardState.enterBoard).not.toHaveBeenCalled();
+    });
+
+    it('does not call enterBoard when the projectId param is empty', async () => {
+      const mounted = await mountBoard('');
+      mounted.fixture.detectChanges();
+      expect(mounted.boardState.enterBoard).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Rendering (shell unchanged from previous revision)', () => {
     it('should render main container with correct layout classes', () => {
       fixture.detectChanges();
 
@@ -47,46 +117,6 @@ describe('BoardPageComponent', () => {
       expect(paragraph).toBeTruthy();
       expect(paragraph.nativeElement.textContent).toContain('Kanban board UI will be implemented here.');
     });
-
-    it('should apply correct heading styles', () => {
-      fixture.detectChanges();
-
-      const heading = fixture.nativeElement.querySelector('h1');
-      expect(heading.classList.contains('text-3xl')).toBe(true);
-      expect(heading.classList.contains('font-bold')).toBe(true);
-      expect(heading.classList.contains('text-gray-800')).toBe(true);
-    });
-
-    it('should apply correct paragraph styles', () => {
-      fixture.detectChanges();
-
-      const paragraph = fixture.nativeElement.querySelector('p');
-      expect(paragraph.classList.contains('mt-4')).toBe(true);
-      expect(paragraph.classList.contains('text-gray-600')).toBe(true);
-    });
-  });
-
-  describe('Layout Structure', () => {
-    it('should have white background for content area', () => {
-      fixture.detectChanges();
-
-      const container = fixture.nativeElement.querySelector('.bg-white');
-      expect(container).toBeTruthy();
-    });
-
-    it('should fill minimum viewport height', () => {
-      fixture.detectChanges();
-
-      const container = fixture.nativeElement.querySelector('.min-h-screen');
-      expect(container).toBeTruthy();
-    });
-
-    it('should have appropriate padding', () => {
-      fixture.detectChanges();
-
-      const container = fixture.nativeElement.querySelector('.p-8');
-      expect(container).toBeTruthy();
-    });
   });
 
   describe('Edge Cases', () => {
@@ -104,34 +134,12 @@ describe('BoardPageComponent', () => {
       const heading = fixture.nativeElement.querySelector('h1');
       expect(heading.textContent).toContain('Board Page');
     });
-
-    it('should display all expected elements', () => {
-      fixture.detectChanges();
-
-      const heading = fixture.nativeElement.querySelector('h1');
-      const paragraph = fixture.nativeElement.querySelector('p');
-      const container = fixture.nativeElement.querySelector('.p-8.bg-white');
-
-      expect(heading).toBeTruthy();
-      expect(paragraph).toBeTruthy();
-      expect(container).toBeTruthy();
-    });
   });
 
   describe('Change Detection Strategy', () => {
     it('should use OnPush change detection', () => {
       expect(component).toBeTruthy();
       expect(fixture.componentRef.changeDetectorRef).toBeTruthy();
-    });
-  });
-
-  describe('Future Integration Points', () => {
-    it('should be ready for kanban board integration', () => {
-      fixture.detectChanges();
-
-      // Verify the main container exists where future board will be added
-      const container = fixture.nativeElement.querySelector('.p-8.bg-white');
-      expect(container).toBeTruthy();
     });
   });
 });

--- a/KanbAI-Web/src/app/features/board/board-page/board-page.component.ts
+++ b/KanbAI-Web/src/app/features/board/board-page/board-page.component.ts
@@ -1,5 +1,24 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  OnDestroy,
+  OnInit,
+  inject
+} from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
 
+import { BoardStateService } from '../state/board-state.service';
+
+/**
+ * Board page shell.
+ *
+ * For issue #46, this component is still a visual placeholder — the kanban
+ * UI lands in #47. Its responsibility in this ticket is lifecycle-only:
+ *  - on init, take the `:projectId` route param and tell {@link BoardStateService}
+ *    to enter that board (sets `currentProjectId`, invokes `JoinProjectGroup`);
+ *  - on destroy, tell the service to leave (clears `currentProjectId`,
+ *    conditionally invokes `LeaveProjectGroup`).
+ */
 @Component({
   selector: 'app-board-page',
   imports: [],
@@ -7,4 +26,22 @@ import { Component, ChangeDetectionStrategy } from '@angular/core';
   styleUrl: './board-page.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class BoardPageComponent {}
+export class BoardPageComponent implements OnInit, OnDestroy {
+  private readonly route = inject(ActivatedRoute);
+  private readonly boardState = inject(BoardStateService);
+
+  ngOnInit(): void {
+    const projectId = this.route.snapshot.paramMap.get('projectId');
+    // Guarded by the route shape `board/:projectId` — the param is always
+    // present in normal navigation. Defensive guard anyway in case this
+    // component is ever mounted under a different path.
+    if (projectId === null || projectId.length === 0) {
+      return;
+    }
+    this.boardState.enterBoard(projectId);
+  }
+
+  ngOnDestroy(): void {
+    this.boardState.leaveBoard();
+  }
+}

--- a/KanbAI-Web/src/app/features/board/state/board-state.model.ts
+++ b/KanbAI-Web/src/app/features/board/state/board-state.model.ts
@@ -1,0 +1,59 @@
+/**
+ * Local projection of a board column. Populated by the `ColumnCreated` /
+ * `ColumnDeleted` real-time events; HTTP-side population is introduced in
+ * #47. Field set mirrors the backend `ColumnResponseDto`, minus
+ * `createdAt` / `updatedAt` (not needed by the board UI at this stage —
+ * add if/when a column detail view requires them).
+ */
+export interface BoardColumn {
+  id: string;
+  name: string;
+  colorCode: string | null;
+  columnOrder: number;
+  projectId: string;
+}
+
+/**
+ * Local projection of a task. Populated by `TaskCreated` / `TaskMoved`
+ * real-time events. Mirrors the backend `TaskResponseDto` minus the
+ * timestamps, for the same reason as {@link BoardColumn}.
+ */
+export interface BoardTask {
+  id: string;
+  title: string;
+  content: string | null;
+  taskOrder: number;
+  columnId: string;
+  assignedId: string | null;
+}
+
+/**
+ * Internal state of {@link BoardStateService}. Never exported from the
+ * service except via read-only selectors.
+ */
+export interface BoardState {
+  /**
+   * Project id the user is currently viewing. Set by `enterBoard(id)`
+   * on `BoardPageComponent.ngOnInit`, cleared by `leaveBoard()` on destroy.
+   * Events arriving while `null` are dropped silently.
+   */
+  currentProjectId: string | null;
+
+  /**
+   * Columns belonging to `currentProjectId`, kept ordered by `columnOrder`.
+   * Empty until an event or (future ticket #47) HTTP load populates it.
+   */
+  columns: BoardColumn[];
+
+  /**
+   * Tasks indexed by `columnId`, each bucket ordered by `taskOrder`.
+   * Empty until an event or (future ticket #47) HTTP load populates it.
+   */
+  tasksByColumnId: Record<string, BoardTask[]>;
+}
+
+export const INITIAL_BOARD_STATE: BoardState = {
+  currentProjectId: null,
+  columns: [],
+  tasksByColumnId: {}
+};

--- a/KanbAI-Web/src/app/features/board/state/board-state.service.spec.ts
+++ b/KanbAI-Web/src/app/features/board/state/board-state.service.spec.ts
@@ -1,0 +1,663 @@
+import { TestBed } from '@angular/core/testing';
+import { Signal, WritableSignal, signal } from '@angular/core';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { Subject } from 'rxjs';
+
+import { BoardStateService } from './board-state.service';
+import {
+  SignalRConnectionState,
+  SignalRService
+} from '../../../core/services/signalr.service';
+import { ProjectStateService } from '../../projects/state/project-state.service';
+import { ProjectSummary } from '../../projects/models/project.model';
+import {
+  ColumnCreatedEvent,
+  ColumnDeletedEvent,
+  REALTIME_EVENT,
+  TaskCreatedEvent,
+  TaskMovedEvent
+} from '../../../core/models/realtime-events';
+
+interface MockSignalRService {
+  connectionState: WritableSignal<SignalRConnectionState>;
+  on: ReturnType<typeof vi.fn>;
+  emit<T>(name: string, payload: T): void;
+  joinProjectGroup: ReturnType<typeof vi.fn>;
+  leaveProjectGroup: ReturnType<typeof vi.fn>;
+  start: ReturnType<typeof vi.fn>;
+  stop: ReturnType<typeof vi.fn>;
+  _subjects: Map<string, Subject<unknown>>;
+}
+
+function createMockSignalRService(
+  initialState: SignalRConnectionState = 'disconnected'
+): MockSignalRService {
+  const subjects = new Map<string, Subject<unknown>>();
+  const connectionState = signal<SignalRConnectionState>(initialState);
+  const onFn = vi.fn((name: string) => {
+    let subject = subjects.get(name);
+    if (!subject) {
+      subject = new Subject<unknown>();
+      subjects.set(name, subject);
+    }
+    return subject.asObservable();
+  });
+  return {
+    connectionState,
+    on: onFn,
+    emit<T>(name: string, payload: T): void {
+      subjects.get(name)?.next(payload);
+    },
+    joinProjectGroup: vi.fn().mockResolvedValue(undefined),
+    leaveProjectGroup: vi.fn().mockResolvedValue(undefined),
+    start: vi.fn().mockResolvedValue(undefined),
+    stop: vi.fn().mockResolvedValue(undefined),
+    _subjects: subjects
+  };
+}
+
+function makeProject(partial?: Partial<ProjectSummary>): ProjectSummary {
+  return {
+    id: 'p-1',
+    name: 'Alpha',
+    description: null,
+    role: 'Owner',
+    createdAt: '2026-04-10T00:00:00Z',
+    updatedAt: '2026-04-10T00:00:00Z',
+    ...partial
+  };
+}
+
+describe('BoardStateService', () => {
+  const PROJECT_ID = 'p-1';
+  const OTHER_PROJECT_ID = 'p-2';
+  let service: BoardStateService;
+  let signalRMock: MockSignalRService;
+  let projectsSig: WritableSignal<ProjectSummary[]>;
+
+  beforeEach(() => {
+    signalRMock = createMockSignalRService('connected');
+    projectsSig = signal<ProjectSummary[]>([makeProject({ id: PROJECT_ID })]);
+
+    const projectsReadonly: Signal<ProjectSummary[]> = projectsSig.asReadonly();
+
+    TestBed.configureTestingModule({
+      providers: [
+        BoardStateService,
+        { provide: SignalRService, useValue: signalRMock },
+        {
+          provide: ProjectStateService,
+          useValue: {
+            projects: projectsReadonly,
+            isLoading: signal(false),
+            error: signal<string | null>(null),
+            hasLoaded: signal(true),
+            loadProjects: () => undefined
+          }
+        }
+      ]
+    });
+
+    service = TestBed.inject(BoardStateService);
+    TestBed.flushEffects();
+  });
+
+  describe('Initial state', () => {
+    it('exposes null currentProjectId and empty buckets', () => {
+      expect(service.currentProjectId()).toBeNull();
+      expect(service.columns()).toEqual([]);
+      expect(service.tasksByColumnId()).toEqual({});
+    });
+  });
+
+  describe('enterBoard() / leaveBoard()', () => {
+    it('enterBoard sets currentProjectId and invokes joinProjectGroup', () => {
+      service.enterBoard(PROJECT_ID);
+      expect(service.currentProjectId()).toBe(PROJECT_ID);
+      expect(signalRMock.joinProjectGroup).toHaveBeenCalledWith(PROJECT_ID);
+    });
+
+    it('enterBoard resets columns/tasks from a prior session', () => {
+      // Seed by entering and emitting a column.
+      service.enterBoard(PROJECT_ID);
+      signalRMock.emit<ColumnCreatedEvent>(REALTIME_EVENT.ColumnCreated, {
+        id: 'col-1',
+        name: 'To Do',
+        colorCode: null,
+        columnOrder: 1,
+        projectId: PROJECT_ID,
+        createdAt: '',
+        updatedAt: ''
+      });
+      expect(service.columns().length).toBe(1);
+
+      // Enter a different board — old state wiped.
+      service.enterBoard(OTHER_PROJECT_ID);
+      expect(service.currentProjectId()).toBe(OTHER_PROJECT_ID);
+      expect(service.columns()).toEqual([]);
+      expect(service.tasksByColumnId()).toEqual({});
+    });
+
+    it('leaveBoard does NOT invoke leaveProjectGroup when user is still a member', () => {
+      service.enterBoard(PROJECT_ID);
+      signalRMock.leaveProjectGroup.mockClear();
+
+      service.leaveBoard();
+      expect(service.currentProjectId()).toBeNull();
+      // User is still a member of PROJECT_ID (seeded in beforeEach).
+      expect(signalRMock.leaveProjectGroup).not.toHaveBeenCalled();
+    });
+
+    it('leaveBoard invokes leaveProjectGroup when user is no longer a member', () => {
+      service.enterBoard(PROJECT_ID);
+
+      // Simulate "user removed mid-session": remove the project from the list.
+      projectsSig.set([]);
+      TestBed.flushEffects();
+      signalRMock.leaveProjectGroup.mockClear();
+
+      service.leaveBoard();
+      expect(signalRMock.leaveProjectGroup).toHaveBeenCalledWith(PROJECT_ID);
+      expect(signalRMock.leaveProjectGroup).toHaveBeenCalledTimes(1);
+    });
+
+    it('leaveBoard is a harmless no-op when currentProjectId is already null', () => {
+      service.leaveBoard();
+      expect(signalRMock.leaveProjectGroup).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Reconnect — re-issues board-scope Join', () => {
+    it('re-joins currentProjectId on connectionState → connected after a drop', () => {
+      service.enterBoard(PROJECT_ID);
+      signalRMock.joinProjectGroup.mockClear();
+
+      signalRMock.connectionState.set('reconnecting');
+      TestBed.flushEffects();
+      signalRMock.connectionState.set('connected');
+      TestBed.flushEffects();
+
+      expect(signalRMock.joinProjectGroup).toHaveBeenCalledWith(PROJECT_ID);
+    });
+
+    it('does NOT re-issue a Join on reconnect when no board is active (currentProjectId === null)', () => {
+      // Sanity: currentProjectId starts as null (no enterBoard yet).
+      expect(service.currentProjectId()).toBeNull();
+      signalRMock.joinProjectGroup.mockClear();
+
+      signalRMock.connectionState.set('reconnecting');
+      TestBed.flushEffects();
+      signalRMock.connectionState.set('connected');
+      TestBed.flushEffects();
+
+      // The board-scope Layer-2 Join must NOT fire — tech spec §"Edge Cases"
+      // gates the reconnect Join on `currentProjectId !== null`.
+      expect(signalRMock.joinProjectGroup).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Logout → login cycle (AC12 — subscribers re-wire to fresh Subjects)', () => {
+    it('a ColumnCreated emitted on a FRESH Subject after a stop()/start() cycle still reconciles', () => {
+      service.enterBoard(PROJECT_ID);
+      // Baseline on the first cycle: event arrives, state updates.
+      signalRMock.emit<ColumnCreatedEvent>(REALTIME_EVENT.ColumnCreated, {
+        id: 'col-before',
+        name: 'Before',
+        colorCode: null,
+        columnOrder: 1,
+        projectId: PROJECT_ID,
+        createdAt: '',
+        updatedAt: ''
+      });
+      expect(service.columns().map(c => c.id)).toEqual(['col-before']);
+
+      // Simulate logout: disconnect + discard the old Subjects (the real
+      // SignalRService.stop() completes every subject and clears its map).
+      signalRMock.connectionState.set('disconnected');
+      TestBed.flushEffects();
+      signalRMock._subjects.clear();
+
+      // Simulate login + re-enter the board. The next `on()` call mints a
+      // FRESH Subject; the service's connection-state effect must re-subscribe
+      // to it so events still land.
+      signalRMock.connectionState.set('connected');
+      TestBed.flushEffects();
+
+      signalRMock.emit<ColumnCreatedEvent>(REALTIME_EVENT.ColumnCreated, {
+        id: 'col-after',
+        name: 'After',
+        colorCode: null,
+        columnOrder: 2,
+        projectId: PROJECT_ID,
+        createdAt: '',
+        updatedAt: ''
+      });
+
+      expect(service.columns().map(c => c.id)).toEqual(['col-before', 'col-after']);
+    });
+  });
+
+  describe('ColumnCreated', () => {
+    beforeEach(() => {
+      service.enterBoard(PROJECT_ID);
+    });
+
+    it('appends when projectId matches the current board', () => {
+      signalRMock.emit<ColumnCreatedEvent>(REALTIME_EVENT.ColumnCreated, {
+        id: 'col-2',
+        name: 'Doing',
+        colorCode: null,
+        columnOrder: 2,
+        projectId: PROJECT_ID,
+        createdAt: '',
+        updatedAt: ''
+      });
+
+      expect(service.columns()).toEqual([
+        {
+          id: 'col-2',
+          name: 'Doing',
+          colorCode: null,
+          columnOrder: 2,
+          projectId: PROJECT_ID
+        }
+      ]);
+    });
+
+    it('maintains columnOrder ascending across multiple emits', () => {
+      signalRMock.emit<ColumnCreatedEvent>(REALTIME_EVENT.ColumnCreated, {
+        id: 'col-b',
+        name: 'B',
+        colorCode: null,
+        columnOrder: 2,
+        projectId: PROJECT_ID,
+        createdAt: '',
+        updatedAt: ''
+      });
+      signalRMock.emit<ColumnCreatedEvent>(REALTIME_EVENT.ColumnCreated, {
+        id: 'col-a',
+        name: 'A',
+        colorCode: null,
+        columnOrder: 1,
+        projectId: PROJECT_ID,
+        createdAt: '',
+        updatedAt: ''
+      });
+
+      expect(service.columns().map(c => c.id)).toEqual(['col-a', 'col-b']);
+    });
+
+    it('ignores a ColumnCreated for a different project', () => {
+      signalRMock.emit<ColumnCreatedEvent>(REALTIME_EVENT.ColumnCreated, {
+        id: 'col-foreign',
+        name: 'Foreign',
+        colorCode: null,
+        columnOrder: 1,
+        projectId: OTHER_PROJECT_ID,
+        createdAt: '',
+        updatedAt: ''
+      });
+      expect(service.columns()).toEqual([]);
+    });
+
+    it('dedupes a ColumnCreated with an id already in state', () => {
+      signalRMock.emit<ColumnCreatedEvent>(REALTIME_EVENT.ColumnCreated, {
+        id: 'col-1',
+        name: 'A',
+        colorCode: null,
+        columnOrder: 1,
+        projectId: PROJECT_ID,
+        createdAt: '',
+        updatedAt: ''
+      });
+      signalRMock.emit<ColumnCreatedEvent>(REALTIME_EVENT.ColumnCreated, {
+        id: 'col-1',
+        name: 'A-dup',
+        colorCode: null,
+        columnOrder: 1,
+        projectId: PROJECT_ID,
+        createdAt: '',
+        updatedAt: ''
+      });
+      expect(service.columns().length).toBe(1);
+      expect(service.columns()[0].name).toBe('A');
+    });
+  });
+
+  describe('ColumnDeleted', () => {
+    beforeEach(() => {
+      service.enterBoard(PROJECT_ID);
+      signalRMock.emit<ColumnCreatedEvent>(REALTIME_EVENT.ColumnCreated, {
+        id: 'col-1',
+        name: 'To Do',
+        colorCode: null,
+        columnOrder: 1,
+        projectId: PROJECT_ID,
+        createdAt: '',
+        updatedAt: ''
+      });
+      signalRMock.emit<TaskCreatedEvent>(REALTIME_EVENT.TaskCreated, {
+        id: 't-1',
+        title: 'T1',
+        content: null,
+        taskOrder: 1,
+        columnId: 'col-1',
+        assignedId: null,
+        createdAt: '',
+        updatedAt: ''
+      });
+    });
+
+    it('removes the column and drops its tasks bucket', () => {
+      expect(service.columns().length).toBe(1);
+      expect(service.tasksByColumnId()['col-1']).toHaveLength(1);
+
+      signalRMock.emit<ColumnDeletedEvent>(REALTIME_EVENT.ColumnDeleted, {
+        columnId: 'col-1',
+        projectId: PROJECT_ID
+      });
+
+      expect(service.columns()).toEqual([]);
+      expect(service.tasksByColumnId()['col-1']).toBeUndefined();
+    });
+
+    it('is a silent no-op when the column is absent', () => {
+      signalRMock.emit<ColumnDeletedEvent>(REALTIME_EVENT.ColumnDeleted, {
+        columnId: 'col-missing',
+        projectId: PROJECT_ID
+      });
+      expect(service.columns().length).toBe(1);
+    });
+
+    it('ignores a ColumnDeleted for a different project', () => {
+      signalRMock.emit<ColumnDeletedEvent>(REALTIME_EVENT.ColumnDeleted, {
+        columnId: 'col-1',
+        projectId: OTHER_PROJECT_ID
+      });
+      expect(service.columns().length).toBe(1);
+    });
+  });
+
+  describe('TaskCreated', () => {
+    beforeEach(() => {
+      service.enterBoard(PROJECT_ID);
+      signalRMock.emit<ColumnCreatedEvent>(REALTIME_EVENT.ColumnCreated, {
+        id: 'col-1',
+        name: 'To Do',
+        colorCode: null,
+        columnOrder: 1,
+        projectId: PROJECT_ID,
+        createdAt: '',
+        updatedAt: ''
+      });
+    });
+
+    it('appends to the matching bucket in taskOrder ascending', () => {
+      signalRMock.emit<TaskCreatedEvent>(REALTIME_EVENT.TaskCreated, {
+        id: 't-b',
+        title: 'B',
+        content: null,
+        taskOrder: 2,
+        columnId: 'col-1',
+        assignedId: null,
+        createdAt: '',
+        updatedAt: ''
+      });
+      signalRMock.emit<TaskCreatedEvent>(REALTIME_EVENT.TaskCreated, {
+        id: 't-a',
+        title: 'A',
+        content: null,
+        taskOrder: 1,
+        columnId: 'col-1',
+        assignedId: null,
+        createdAt: '',
+        updatedAt: ''
+      });
+      expect(service.tasksByColumnId()['col-1'].map(t => t.id)).toEqual(['t-a', 't-b']);
+    });
+
+    it('is a silent no-op when the target column is unknown', () => {
+      signalRMock.emit<TaskCreatedEvent>(REALTIME_EVENT.TaskCreated, {
+        id: 't-orphan',
+        title: 'Orphan',
+        content: null,
+        taskOrder: 1,
+        columnId: 'col-missing',
+        assignedId: null,
+        createdAt: '',
+        updatedAt: ''
+      });
+      expect(service.tasksByColumnId()).toEqual({});
+    });
+
+    it('is a silent no-op when no currentProjectId is set', () => {
+      service.leaveBoard();
+      expect(service.currentProjectId()).toBeNull();
+      signalRMock.emit<TaskCreatedEvent>(REALTIME_EVENT.TaskCreated, {
+        id: 't-1',
+        title: 'T',
+        content: null,
+        taskOrder: 1,
+        columnId: 'col-1',
+        assignedId: null,
+        createdAt: '',
+        updatedAt: ''
+      });
+      expect(service.tasksByColumnId()).toEqual({});
+    });
+
+    it('dedupes a TaskCreated whose id is already in the bucket', () => {
+      signalRMock.emit<TaskCreatedEvent>(REALTIME_EVENT.TaskCreated, {
+        id: 't-1',
+        title: 'First',
+        content: null,
+        taskOrder: 1,
+        columnId: 'col-1',
+        assignedId: null,
+        createdAt: '',
+        updatedAt: ''
+      });
+      signalRMock.emit<TaskCreatedEvent>(REALTIME_EVENT.TaskCreated, {
+        id: 't-1',
+        title: 'Dup',
+        content: null,
+        taskOrder: 1,
+        columnId: 'col-1',
+        assignedId: null,
+        createdAt: '',
+        updatedAt: ''
+      });
+      const bucket = service.tasksByColumnId()['col-1'];
+      expect(bucket.length).toBe(1);
+      expect(bucket[0].title).toBe('First');
+    });
+  });
+
+  describe('TaskMoved', () => {
+    beforeEach(() => {
+      service.enterBoard(PROJECT_ID);
+      for (const column of ['col-1', 'col-2']) {
+        signalRMock.emit<ColumnCreatedEvent>(REALTIME_EVENT.ColumnCreated, {
+          id: column,
+          name: column,
+          colorCode: null,
+          columnOrder: column === 'col-1' ? 1 : 2,
+          projectId: PROJECT_ID,
+          createdAt: '',
+          updatedAt: ''
+        });
+      }
+      signalRMock.emit<TaskCreatedEvent>(REALTIME_EVENT.TaskCreated, {
+        id: 't-1',
+        title: 'Task 1',
+        content: null,
+        taskOrder: 1,
+        columnId: 'col-1',
+        assignedId: null,
+        createdAt: '',
+        updatedAt: ''
+      });
+    });
+
+    it('removes from oldColumnId and inserts into newColumnId', () => {
+      signalRMock.emit<TaskMovedEvent>(REALTIME_EVENT.TaskMoved, {
+        taskId: 't-1',
+        oldColumnId: 'col-1',
+        newColumnId: 'col-2',
+        oldTaskOrder: 1,
+        newTaskOrder: 1,
+        task: {
+          id: 't-1',
+          title: 'Task 1',
+          content: null,
+          taskOrder: 1,
+          columnId: 'col-2',
+          assignedId: null,
+          createdAt: '',
+          updatedAt: ''
+        }
+      });
+
+      const buckets = service.tasksByColumnId();
+      expect(buckets['col-1']).toEqual([]);
+      expect(buckets['col-2'].map(t => t.id)).toEqual(['t-1']);
+      expect(buckets['col-2'][0].columnId).toBe('col-2');
+    });
+
+    it('is a silent no-op when the task is not in local state', () => {
+      signalRMock.emit<TaskMovedEvent>(REALTIME_EVENT.TaskMoved, {
+        taskId: 't-unknown',
+        oldColumnId: 'col-1',
+        newColumnId: 'col-2',
+        oldTaskOrder: 1,
+        newTaskOrder: 1,
+        task: {
+          id: 't-unknown',
+          title: 'T',
+          content: null,
+          taskOrder: 1,
+          columnId: 'col-2',
+          assignedId: null,
+          createdAt: '',
+          updatedAt: ''
+        }
+      });
+      // col-1 still holds t-1; col-2 is untouched.
+      expect(service.tasksByColumnId()['col-1'].map(t => t.id)).toEqual(['t-1']);
+      expect(service.tasksByColumnId()['col-2']).toBeUndefined();
+    });
+
+    it('is a silent no-op when currentProjectId is null', () => {
+      service.leaveBoard();
+      signalRMock.emit<TaskMovedEvent>(REALTIME_EVENT.TaskMoved, {
+        taskId: 't-1',
+        oldColumnId: 'col-1',
+        newColumnId: 'col-2',
+        oldTaskOrder: 1,
+        newTaskOrder: 1,
+        task: {
+          id: 't-1',
+          title: 'Task 1',
+          content: null,
+          taskOrder: 1,
+          columnId: 'col-2',
+          assignedId: null,
+          createdAt: '',
+          updatedAt: ''
+        }
+      });
+      expect(service.tasksByColumnId()).toEqual({});
+    });
+  });
+
+  describe('Malformed / partial payloads', () => {
+    beforeEach(() => {
+      service.enterBoard(PROJECT_ID);
+    });
+
+    it('each handler is no-throw on undefined/empty payloads', () => {
+      const malformed: unknown[] = [
+        undefined,
+        null,
+        {},
+        { projectId: undefined },
+        { id: null }
+      ];
+      expect(() => {
+        for (const payload of malformed) {
+          signalRMock.emit(REALTIME_EVENT.ColumnCreated, payload as ColumnCreatedEvent);
+          signalRMock.emit(REALTIME_EVENT.ColumnDeleted, payload as ColumnDeletedEvent);
+          signalRMock.emit(REALTIME_EVENT.TaskCreated, payload as TaskCreatedEvent);
+          signalRMock.emit(REALTIME_EVENT.TaskMoved, payload as TaskMovedEvent);
+        }
+      }).not.toThrow();
+    });
+  });
+
+  describe('Console hygiene', () => {
+    it('never logs payload fields on any path', () => {
+      const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+      const SECRET_PROJECT = 'secret-project-id';
+      const SECRET_COLUMN = 'secret-column-id';
+      const SECRET_TASK = 'secret-task-id';
+
+      service.enterBoard(SECRET_PROJECT);
+      signalRMock.emit<ColumnCreatedEvent>(REALTIME_EVENT.ColumnCreated, {
+        id: SECRET_COLUMN,
+        name: 'X',
+        colorCode: null,
+        columnOrder: 1,
+        projectId: SECRET_PROJECT,
+        createdAt: '',
+        updatedAt: ''
+      });
+      signalRMock.emit<TaskCreatedEvent>(REALTIME_EVENT.TaskCreated, {
+        id: SECRET_TASK,
+        title: 'X',
+        content: null,
+        taskOrder: 1,
+        columnId: SECRET_COLUMN,
+        assignedId: null,
+        createdAt: '',
+        updatedAt: ''
+      });
+      signalRMock.emit<TaskMovedEvent>(REALTIME_EVENT.TaskMoved, {
+        taskId: SECRET_TASK,
+        oldColumnId: SECRET_COLUMN,
+        newColumnId: SECRET_COLUMN,
+        oldTaskOrder: 1,
+        newTaskOrder: 2,
+        task: {
+          id: SECRET_TASK,
+          title: 'X',
+          content: null,
+          taskOrder: 2,
+          columnId: SECRET_COLUMN,
+          assignedId: null,
+          createdAt: '',
+          updatedAt: ''
+        }
+      });
+      signalRMock.emit<ColumnDeletedEvent>(REALTIME_EVENT.ColumnDeleted, {
+        columnId: SECRET_COLUMN,
+        projectId: SECRET_PROJECT
+      });
+
+      const allArgs = [
+        ...consoleLogSpy.mock.calls.flat(),
+        ...consoleErrorSpy.mock.calls.flat()
+      ];
+      for (const arg of allArgs) {
+        const asString = typeof arg === 'string' ? arg : JSON.stringify(arg);
+        expect(asString).not.toContain(SECRET_PROJECT);
+        expect(asString).not.toContain(SECRET_COLUMN);
+        expect(asString).not.toContain(SECRET_TASK);
+      }
+
+      consoleLogSpy.mockRestore();
+      consoleErrorSpy.mockRestore();
+    });
+  });
+});

--- a/KanbAI-Web/src/app/features/board/state/board-state.service.ts
+++ b/KanbAI-Web/src/app/features/board/state/board-state.service.ts
@@ -1,0 +1,270 @@
+import { DestroyRef, Injectable, Signal, effect, inject } from '@angular/core';
+import { Subscription } from 'rxjs';
+
+import { BaseStateService } from '../../../core/state/base-state.service';
+import { SignalRService } from '../../../core/services/signalr.service';
+import { ProjectStateService } from '../../projects/state/project-state.service';
+import {
+  ColumnCreatedEvent,
+  ColumnDeletedEvent,
+  REALTIME_EVENT,
+  TaskCreatedEvent,
+  TaskMovedEvent
+} from '../../../core/models/realtime-events';
+import {
+  BoardColumn,
+  BoardState,
+  BoardTask,
+  INITIAL_BOARD_STATE
+} from './board-state.model';
+
+/**
+ * Board-scope state + realtime reconciler.
+ *
+ * Owns the `currentProjectId` + `columns` + `tasksByColumnId` slice, drives
+ * `JoinProjectGroup` / `LeaveProjectGroup` via {@link SignalRService} for the
+ * currently-viewed board (the "Layer 2" join described in the tech spec),
+ * and reconciles the four board-scope events into local state.
+ *
+ * All reconciliation is idempotent and silent-no-op on missing entities —
+ * see issue_46_tech_spec.md §"Event handlers → BoardStateService" and AC11
+ * in issue_46_context.md.
+ */
+@Injectable({ providedIn: 'root' })
+export class BoardStateService extends BaseStateService<BoardState> {
+  private readonly signalRService = inject(SignalRService);
+  private readonly projectStateService = inject(ProjectStateService);
+  private readonly destroyRef = inject(DestroyRef);
+
+  /**
+   * Active event subscriptions. Refreshed on every `connectionState → 'connected'`
+   * transition so the subjects emitted after a `stop()`/`start()` cycle
+   * (e.g. logout → login) land in fresh subscribers.
+   */
+  private subscriptionBag: Subscription[] = [];
+
+  /** Public selectors. */
+  readonly currentProjectId: Signal<string | null> = this.select(s => s.currentProjectId);
+  readonly columns: Signal<BoardColumn[]> = this.select(s => s.columns);
+  readonly tasksByColumnId: Signal<Record<string, BoardTask[]>> = this.select(
+    s => s.tasksByColumnId
+  );
+
+  constructor() {
+    super();
+
+    // (Re)subscribe to the four board events on every connect. Also
+    // re-joins the current board group on reconnect — see Edge Cases in
+    // the tech spec ("Reconnect during board session").
+    effect(() => {
+      const state = this.signalRService.connectionState();
+      if (state !== 'connected') {
+        return;
+      }
+
+      this.teardownSubscriptions();
+
+      this.subscriptionBag.push(
+        this.signalRService
+          .on<ColumnCreatedEvent>(REALTIME_EVENT.ColumnCreated)
+          .subscribe(evt => this.onColumnCreated(evt))
+      );
+      this.subscriptionBag.push(
+        this.signalRService
+          .on<ColumnDeletedEvent>(REALTIME_EVENT.ColumnDeleted)
+          .subscribe(evt => this.onColumnDeleted(evt))
+      );
+      this.subscriptionBag.push(
+        this.signalRService
+          .on<TaskCreatedEvent>(REALTIME_EVENT.TaskCreated)
+          .subscribe(evt => this.onTaskCreated(evt))
+      );
+      this.subscriptionBag.push(
+        this.signalRService
+          .on<TaskMovedEvent>(REALTIME_EVENT.TaskMoved)
+          .subscribe(evt => this.onTaskMoved(evt))
+      );
+
+      // If a board session straddled a reconnect, the server-side group
+      // membership was wiped on disconnect. Re-issue the board-scope join
+      // so task/column broadcasts keep flowing.
+      const active = this.getState().currentProjectId;
+      if (active !== null) {
+        void this.signalRService.joinProjectGroup(active);
+      }
+    });
+
+    this.destroyRef.onDestroy(() => this.teardownSubscriptions());
+  }
+
+  protected getInitialState(): BoardState {
+    return INITIAL_BOARD_STATE;
+  }
+
+  /**
+   * Called by `BoardPageComponent.ngOnInit(projectId)`. Clears any state
+   * held for a previously viewed board, records the new `currentProjectId`,
+   * and invokes `JoinProjectGroup` so task/column broadcasts flow.
+   */
+  enterBoard(projectId: string): void {
+    this.setState({
+      currentProjectId: projectId,
+      columns: [],
+      tasksByColumnId: {}
+    });
+    void this.signalRService.joinProjectGroup(projectId);
+  }
+
+  /**
+   * Called by `BoardPageComponent.ngOnDestroy`. Clears board-scope state
+   * and invokes `LeaveProjectGroup` ONLY IF the project is no longer in
+   * the user's current project list — otherwise `ProjectStateService`
+   * (Layer 1) still wants the group retained so dashboard-scope events
+   * keep arriving. See tech spec §"Join strategy — two layers".
+   */
+  leaveBoard(): void {
+    const projectId = this.getState().currentProjectId;
+    this.setState({
+      currentProjectId: null,
+      columns: [],
+      tasksByColumnId: {}
+    });
+    if (projectId === null) {
+      return;
+    }
+    const stillAMember = this.projectStateService
+      .projects()
+      .some(p => p.id === projectId);
+    if (!stillAMember) {
+      void this.signalRService.leaveProjectGroup(projectId);
+    }
+  }
+
+  // ------------------- event handlers -------------------
+
+  /**
+   * Append when projectId matches the current board; ignore otherwise.
+   * Dedupe by id. Maintains `columnOrder` ascending.
+   */
+  private onColumnCreated(evt: ColumnCreatedEvent): void {
+    if (!evt || evt.projectId !== this.getState().currentProjectId) {
+      return;
+    }
+    const current = this.getState().columns;
+    if (current.some(c => c.id === evt.id)) {
+      return;
+    }
+    const next = [
+      ...current,
+      {
+        id: evt.id,
+        name: evt.name,
+        colorCode: evt.colorCode,
+        columnOrder: evt.columnOrder,
+        projectId: evt.projectId
+      }
+    ].sort((a, b) => a.columnOrder - b.columnOrder);
+    this.setState({ columns: next });
+  }
+
+  /**
+   * Remove the column and drop its task bucket. No-op if absent.
+   */
+  private onColumnDeleted(evt: ColumnDeletedEvent): void {
+    if (!evt || evt.projectId !== this.getState().currentProjectId) {
+      return;
+    }
+    const current = this.getState().columns;
+    const nextColumns = current.filter(c => c.id !== evt.columnId);
+    if (nextColumns.length === current.length) {
+      return;
+    }
+    const tasksByColumnId = { ...this.getState().tasksByColumnId };
+    delete tasksByColumnId[evt.columnId];
+    this.setState({ columns: nextColumns, tasksByColumnId });
+  }
+
+  /**
+   * Append to the bucket of `evt.columnId` iff that column is known.
+   * Dedupe by id. Maintains `taskOrder` ascending.
+   *
+   * Attribution: the backend only broadcasts to the joined group, so the
+   * combination of (client is in this group) + (`currentProjectId !== null`)
+   * + (column exists in state) is sufficient. A `TaskCreated` for a column
+   * that isn't in state is silently dropped per AC11.
+   */
+  private onTaskCreated(evt: TaskCreatedEvent): void {
+    if (!evt || this.getState().currentProjectId === null) {
+      return;
+    }
+    const column = this.getState().columns.find(c => c.id === evt.columnId);
+    if (!column) {
+      return;
+    }
+    const bucket = this.getState().tasksByColumnId[evt.columnId] ?? [];
+    if (bucket.some(t => t.id === evt.id)) {
+      return;
+    }
+    const newTask: BoardTask = {
+      id: evt.id,
+      title: evt.title,
+      content: evt.content,
+      taskOrder: evt.taskOrder,
+      columnId: evt.columnId,
+      assignedId: evt.assignedId
+    };
+    const next = [...bucket, newTask].sort((a, b) => a.taskOrder - b.taskOrder);
+    this.setState({
+      tasksByColumnId: {
+        ...this.getState().tasksByColumnId,
+        [evt.columnId]: next
+      }
+    });
+  }
+
+  /**
+   * Move a task from `oldColumnId` to `newColumnId`.
+   *  - If the task is not present in the old bucket, silent no-op (AC11).
+   *  - The new row comes from `evt.task` (full post-move TaskResponseDto)
+   *    so we don't have to reach for any pre-move fields.
+   */
+  private onTaskMoved(evt: TaskMovedEvent): void {
+    if (!evt || !evt.task || this.getState().currentProjectId === null) {
+      return;
+    }
+    const buckets = this.getState().tasksByColumnId;
+    const oldBucket = buckets[evt.oldColumnId] ?? [];
+    const existsOld = oldBucket.some(t => t.id === evt.taskId);
+    if (!existsOld) {
+      return;
+    }
+    const newOldBucket = oldBucket.filter(t => t.id !== evt.taskId);
+    const newBucket = buckets[evt.newColumnId] ?? [];
+    const movedTask: BoardTask = {
+      id: evt.task.id,
+      title: evt.task.title,
+      content: evt.task.content,
+      taskOrder: evt.task.taskOrder,
+      columnId: evt.task.columnId,
+      assignedId: evt.task.assignedId
+    };
+    const inserted = [
+      ...newBucket.filter(t => t.id !== movedTask.id),
+      movedTask
+    ].sort((a, b) => a.taskOrder - b.taskOrder);
+    this.setState({
+      tasksByColumnId: {
+        ...buckets,
+        [evt.oldColumnId]: newOldBucket,
+        [evt.newColumnId]: inserted
+      }
+    });
+  }
+
+  private teardownSubscriptions(): void {
+    for (const sub of this.subscriptionBag) {
+      sub.unsubscribe();
+    }
+    this.subscriptionBag = [];
+  }
+}

--- a/KanbAI-Web/src/app/features/projects/components/members-dialog/members-dialog.component.spec.ts
+++ b/KanbAI-Web/src/app/features/projects/components/members-dialog/members-dialog.component.spec.ts
@@ -46,6 +46,8 @@ interface MembersStateMock {
   loadMembers: ReturnType<typeof vi.fn>;
   addMemberByEmail: ReturnType<typeof vi.fn>;
   removeMember: ReturnType<typeof vi.fn>;
+  setCurrentProjectContext: ReturnType<typeof vi.fn>;
+  clearCurrentProjectContext: ReturnType<typeof vi.fn>;
 }
 
 interface DialogMock {
@@ -87,7 +89,9 @@ async function mount(options: MountOptions = {}): Promise<{
     ),
     removeMember: vi.fn(
       options.removeImpl ?? ((_userId: string) => of(void 0))
-    )
+    ),
+    setCurrentProjectContext: vi.fn(),
+    clearCurrentProjectContext: vi.fn()
   };
 
   const dialog: DialogMock = {
@@ -134,6 +138,17 @@ describe('MembersDialogComponent', () => {
   it('calls loadMembers on init with the project id', async () => {
     const { membersState } = await mount();
     expect(membersState.loadMembers).toHaveBeenCalledWith('p-1');
+  });
+
+  it('sets the members-state realtime context to the open project id on init', async () => {
+    const { membersState } = await mount();
+    expect(membersState.setCurrentProjectContext).toHaveBeenCalledWith('p-1');
+  });
+
+  it('clears the members-state realtime context on destroy', async () => {
+    const { fixture, membersState } = await mount();
+    fixture.destroy();
+    expect(membersState.clearCurrentProjectContext).toHaveBeenCalledTimes(1);
   });
 
   it('renders the heading with the project name (id="members-dialog-title")', async () => {

--- a/KanbAI-Web/src/app/features/projects/components/members-dialog/members-dialog.component.ts
+++ b/KanbAI-Web/src/app/features/projects/components/members-dialog/members-dialog.component.ts
@@ -122,6 +122,13 @@ export class MembersDialogComponent implements OnInit {
 
   ngOnInit(): void {
     this.liveMessage.set('Loading members…');
+    // Attribute `MemberAdded` realtime events to this project while the
+    // dialog is open — the event payload carries no projectId (see
+    // `MembersStateService.onMemberAdded`). Context is cleared on destroy.
+    this.membersState.setCurrentProjectContext(this.data.project.id);
+    this.destroyRef.onDestroy(() => {
+      this.membersState.clearCurrentProjectContext();
+    });
     this.membersState.loadMembers(this.data.project.id);
   }
 

--- a/KanbAI-Web/src/app/features/projects/state/members-state.service.spec.ts
+++ b/KanbAI-Web/src/app/features/projects/state/members-state.service.spec.ts
@@ -2,15 +2,63 @@ import { TestBed } from '@angular/core/testing';
 import { provideHttpClient } from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { WritableSignal, signal } from '@angular/core';
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { Subject } from 'rxjs';
 
 import { MembersStateService } from './members-state.service';
 import { ProjectStateService } from './project-state.service';
 import { AuthService } from '../../../core/services/AuthService';
+import {
+  SignalRConnectionState,
+  SignalRService
+} from '../../../core/services/signalr.service';
+import {
+  MemberAddedEvent,
+  MemberRemovedEvent,
+  REALTIME_EVENT
+} from '../../../core/models/realtime-events';
 import { UserProfileDto } from '../../../core/models/auth.models';
 import { ProjectSummary } from '../models/project.model';
 import { MemberSummary, MembersListResponse, AddMemberResponse } from '../models/member.model';
 import { environment } from '../../../../environments/environment';
+
+interface MockSignalRService {
+  connectionState: WritableSignal<SignalRConnectionState>;
+  on: ReturnType<typeof vi.fn>;
+  emit<T>(name: string, payload: T): void;
+  joinProjectGroup: ReturnType<typeof vi.fn>;
+  leaveProjectGroup: ReturnType<typeof vi.fn>;
+  start: ReturnType<typeof vi.fn>;
+  stop: ReturnType<typeof vi.fn>;
+  _subjects: Map<string, Subject<unknown>>;
+}
+
+function createMockSignalRService(
+  initialState: SignalRConnectionState = 'disconnected'
+): MockSignalRService {
+  const subjects = new Map<string, Subject<unknown>>();
+  const connectionState = signal<SignalRConnectionState>(initialState);
+  const onFn = vi.fn((name: string) => {
+    let subject = subjects.get(name);
+    if (!subject) {
+      subject = new Subject<unknown>();
+      subjects.set(name, subject);
+    }
+    return subject.asObservable();
+  });
+  return {
+    connectionState,
+    on: onFn,
+    emit<T>(name: string, payload: T): void {
+      subjects.get(name)?.next(payload);
+    },
+    joinProjectGroup: vi.fn().mockResolvedValue(undefined),
+    leaveProjectGroup: vi.fn().mockResolvedValue(undefined),
+    start: vi.fn().mockResolvedValue(undefined),
+    stop: vi.fn().mockResolvedValue(undefined),
+    _subjects: subjects
+  };
+}
 
 const BASE_URL = `${environment.apiUrl}/project`;
 const PROJECT_ID = 'proj-1';
@@ -45,10 +93,12 @@ describe('MembersStateService', () => {
   let httpMock: HttpTestingController;
   let currentUserSig: WritableSignal<UserProfileDto | null>;
   let projectsSig: WritableSignal<ProjectSummary[]>;
+  let signalRMock: MockSignalRService;
 
   beforeEach(() => {
     currentUserSig = signal<UserProfileDto | null>(MOCK_USER);
     projectsSig = signal<ProjectSummary[]>([makeProject()]);
+    signalRMock = createMockSignalRService('disconnected');
 
     TestBed.configureTestingModule({
       providers: [
@@ -73,7 +123,8 @@ describe('MembersStateService', () => {
             hasLoaded: signal(true),
             loadProjects: () => undefined
           }
-        }
+        },
+        { provide: SignalRService, useValue: signalRMock }
       ]
     });
 
@@ -350,6 +401,198 @@ describe('MembersStateService', () => {
 
       expect(service.selectForProject(PROJECT_ID)().members).toEqual([]);
       expect(service.selectForProject(PROJECT_ID)().hasLoaded).toBe(false);
+    });
+  });
+
+  describe('real-time events', () => {
+    /** Seeds a slice and transitions the mock connection to 'connected'. */
+    function seedSliceAndConnect(members: MemberSummary[]): void {
+      service.loadMembers(PROJECT_ID);
+      httpMock.expectOne(`${BASE_URL}/${PROJECT_ID}/members`).flush({
+        success: true,
+        message: null,
+        errors: [],
+        data: members
+      } satisfies MembersListResponse);
+      signalRMock.connectionState.set('connected');
+      TestBed.flushEffects();
+    }
+
+    describe('MemberRemoved', () => {
+      it('removes the user from the matching slice on event arrival', () => {
+        seedSliceAndConnect([
+          makeMember({ userId: 'u-1' }),
+          makeMember({ userId: 'u-2', name: 'Bob' })
+        ]);
+
+        signalRMock.emit<MemberRemovedEvent>(REALTIME_EVENT.MemberRemoved, {
+          projectId: PROJECT_ID,
+          userId: 'u-1'
+        });
+
+        expect(
+          service.selectForProject(PROJECT_ID)().members.map(m => m.userId)
+        ).toEqual(['u-2']);
+      });
+
+      it('is a silent no-op when the slice is missing', () => {
+        // Transition to connected WITHOUT loading the slice first.
+        signalRMock.connectionState.set('connected');
+        TestBed.flushEffects();
+
+        signalRMock.emit<MemberRemovedEvent>(REALTIME_EVENT.MemberRemoved, {
+          projectId: 'p-unknown',
+          userId: 'u-x'
+        });
+
+        // No slice was created.
+        expect(service.selectForProject('p-unknown')().hasLoaded).toBe(false);
+      });
+
+      it('is a silent no-op when the user is not in the slice', () => {
+        seedSliceAndConnect([makeMember({ userId: 'u-1' })]);
+
+        signalRMock.emit<MemberRemovedEvent>(REALTIME_EVENT.MemberRemoved, {
+          projectId: PROJECT_ID,
+          userId: 'u-missing'
+        });
+
+        expect(
+          service.selectForProject(PROJECT_ID)().members.map(m => m.userId)
+        ).toEqual(['u-1']);
+      });
+    });
+
+    describe('MemberAdded', () => {
+      it('appends when context is set to the matching project', () => {
+        seedSliceAndConnect([makeMember({ userId: 'u-1' })]);
+        service.setCurrentProjectContext(PROJECT_ID);
+
+        const added: MemberAddedEvent = {
+          userId: 'u-new',
+          name: 'New',
+          email: 'new@example.com',
+          role: 'Member',
+          joinedAt: '2026-04-30T00:00:00Z'
+        };
+        signalRMock.emit(REALTIME_EVENT.MemberAdded, added);
+
+        expect(
+          service.selectForProject(PROJECT_ID)().members.map(m => m.userId)
+        ).toEqual(['u-1', 'u-new']);
+      });
+
+      it('drops the event when no context is set', () => {
+        seedSliceAndConnect([makeMember({ userId: 'u-1' })]);
+        // Intentionally do NOT set context.
+
+        signalRMock.emit<MemberAddedEvent>(REALTIME_EVENT.MemberAdded, {
+          userId: 'u-new',
+          name: 'New',
+          email: 'new@example.com',
+          role: 'Member',
+          joinedAt: '2026-04-30T00:00:00Z'
+        });
+
+        expect(
+          service.selectForProject(PROJECT_ID)().members.map(m => m.userId)
+        ).toEqual(['u-1']);
+      });
+
+      it('dedupes a MemberAdded event that mirrors a locally-added row', () => {
+        seedSliceAndConnect([
+          makeMember({ userId: 'u-1' }),
+          makeMember({ userId: 'u-just-added', name: 'Just Added' })
+        ]);
+        service.setCurrentProjectContext(PROJECT_ID);
+
+        signalRMock.emit<MemberAddedEvent>(REALTIME_EVENT.MemberAdded, {
+          userId: 'u-just-added',
+          name: 'Just Added',
+          email: 'j@example.com',
+          role: 'Member',
+          joinedAt: '2026-04-30T00:00:00Z'
+        });
+
+        expect(
+          service.selectForProject(PROJECT_ID)().members.map(m => m.userId)
+        ).toEqual(['u-1', 'u-just-added']);
+      });
+
+      it('setCurrentProjectContext / clearCurrentProjectContext flip currentProjectContext', () => {
+        expect(service.currentProjectContext()).toBeNull();
+        service.setCurrentProjectContext(PROJECT_ID);
+        expect(service.currentProjectContext()).toBe(PROJECT_ID);
+        service.clearCurrentProjectContext();
+        expect(service.currentProjectContext()).toBeNull();
+      });
+    });
+
+    describe('Subscription teardown on disconnect (AC12 defense in depth)', () => {
+      it('stops reconciling MemberRemoved after connectionState leaves connected', () => {
+        seedSliceAndConnect([
+          makeMember({ userId: 'u-1' }),
+          makeMember({ userId: 'u-2', name: 'Bob' })
+        ]);
+        // Baseline: removal is reconciled while connected.
+        signalRMock.emit<MemberRemovedEvent>(REALTIME_EVENT.MemberRemoved, {
+          projectId: PROJECT_ID,
+          userId: 'u-1'
+        });
+        expect(
+          service.selectForProject(PROJECT_ID)().members.map(m => m.userId)
+        ).toEqual(['u-2']);
+
+        // Disconnect: the effect should tear down subscribers.
+        signalRMock.connectionState.set('disconnected');
+        TestBed.flushEffects();
+
+        // Emit on the stale Subject — if teardown worked, the handler is
+        // gone and state is untouched.
+        signalRMock.emit<MemberRemovedEvent>(REALTIME_EVENT.MemberRemoved, {
+          projectId: PROJECT_ID,
+          userId: 'u-2'
+        });
+        expect(
+          service.selectForProject(PROJECT_ID)().members.map(m => m.userId)
+        ).toEqual(['u-2']);
+      });
+    });
+
+    describe('Console hygiene', () => {
+      it('never logs payload fields in handler execution', () => {
+        const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+        const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+        seedSliceAndConnect([makeMember({ userId: 'secret-user-id' })]);
+        service.setCurrentProjectContext(PROJECT_ID);
+
+        signalRMock.emit<MemberAddedEvent>(REALTIME_EVENT.MemberAdded, {
+          userId: 'another-secret-id',
+          name: 'Name',
+          email: 'private@example.com',
+          role: 'Member',
+          joinedAt: '2026-04-30T00:00:00Z'
+        });
+        signalRMock.emit<MemberRemovedEvent>(REALTIME_EVENT.MemberRemoved, {
+          projectId: PROJECT_ID,
+          userId: 'secret-user-id'
+        });
+
+        const allArgs = [
+          ...consoleLogSpy.mock.calls.flat(),
+          ...consoleErrorSpy.mock.calls.flat()
+        ];
+        for (const arg of allArgs) {
+          const asString = typeof arg === 'string' ? arg : JSON.stringify(arg);
+          expect(asString).not.toContain('secret-user-id');
+          expect(asString).not.toContain('another-secret-id');
+          expect(asString).not.toContain('private@example.com');
+        }
+
+        consoleLogSpy.mockRestore();
+        consoleErrorSpy.mockRestore();
+      });
     });
   });
 });

--- a/KanbAI-Web/src/app/features/projects/state/members-state.service.ts
+++ b/KanbAI-Web/src/app/features/projects/state/members-state.service.ts
@@ -1,10 +1,19 @@
-import { Injectable, Signal, computed, effect, inject } from '@angular/core';
+import {
+  DestroyRef,
+  Injectable,
+  Signal,
+  computed,
+  effect,
+  inject,
+  signal
+} from '@angular/core';
 import { Observable, Subscription, of, throwError } from 'rxjs';
 import { catchError, tap } from 'rxjs/operators';
 import { HttpErrorResponse } from '@angular/common/http';
 
 import { BaseStateService } from '../../../core/state/base-state.service';
 import { AuthService } from '../../../core/services/AuthService';
+import { SignalRService } from '../../../core/services/signalr.service';
 import { MemberSummary } from '../models/member.model';
 import {
   INITIAL_MEMBERS_STATE,
@@ -17,6 +26,11 @@ import {
   mapMemberErrorToUserMessage
 } from '../services/members-api.service';
 import { ProjectStateService } from './project-state.service';
+import {
+  MemberAddedEvent,
+  MemberRemovedEvent,
+  REALTIME_EVENT
+} from '../../../core/models/realtime-events';
 
 /**
  * Per-project members cache.
@@ -39,9 +53,30 @@ export class MembersStateService extends BaseStateService<MembersState> {
   private readonly membersApi = inject(MembersApiService);
   private readonly authService = inject(AuthService);
   private readonly projectState = inject(ProjectStateService);
+  private readonly signalRService = inject(SignalRService);
+  private readonly destroyRef = inject(DestroyRef);
 
   /** Map<projectId, Subscription> for in-flight list loads. */
   private readonly inFlightLoads: Map<string, Subscription> = new Map();
+
+  /**
+   * Active real-time event subscriptions. Refreshed on every
+   * `connectionState → 'connected'` transition so a post-logout login
+   * re-subscribes against the fresh Subjects minted after `stop()`/`start()`.
+   */
+  private realtimeSubscriptions: Subscription[] = [];
+
+  /**
+   * Id of the project whose members dialog is currently open, if any.
+   * Drives attribution for the `MemberAdded` event, whose payload does
+   * not carry a `projectId` (see tech spec §"Known Backend Contract
+   * Caveats"). Set by {@link setCurrentProjectContext} on dialog open,
+   * cleared by {@link clearCurrentProjectContext} on dialog close.
+   */
+  private readonly contextSignal = signal<string | null>(null);
+
+  /** Read-only context signal. Consumed by the dialog component's tests. */
+  readonly currentProjectContext = this.contextSignal.asReadonly();
 
   constructor() {
     super();
@@ -62,6 +97,42 @@ export class MembersStateService extends BaseStateService<MembersState> {
       const ids = new Set(this.projectState.projects().map(p => p.id));
       this.pruneRemovedProjects(ids);
     });
+
+    // Real-time subscriber registration — re-runs on every connection-state
+    // transition so post-logout logins re-wire against fresh Subjects.
+    effect(() => {
+      const state = this.signalRService.connectionState();
+      if (state !== 'connected') {
+        this.teardownRealtimeSubscriptions();
+        return;
+      }
+      this.teardownRealtimeSubscriptions();
+      this.realtimeSubscriptions.push(
+        this.signalRService
+          .on<MemberAddedEvent>(REALTIME_EVENT.MemberAdded)
+          .subscribe(evt => this.onMemberAdded(evt))
+      );
+      this.realtimeSubscriptions.push(
+        this.signalRService
+          .on<MemberRemovedEvent>(REALTIME_EVENT.MemberRemoved)
+          .subscribe(evt => this.onMemberRemoved(evt))
+      );
+    });
+
+    this.destroyRef.onDestroy(() => this.teardownRealtimeSubscriptions());
+  }
+
+  /**
+   * Called by the members-dialog component on open. Attribution hook for
+   * `MemberAdded` events, whose payload lacks `projectId`.
+   */
+  setCurrentProjectContext(projectId: string): void {
+    this.contextSignal.set(projectId);
+  }
+
+  /** Called by the members-dialog component on close. */
+  clearCurrentProjectContext(): void {
+    this.contextSignal.set(null);
   }
 
   protected getInitialState(): MembersState {
@@ -233,5 +304,59 @@ export class MembersStateService extends BaseStateService<MembersState> {
       typeof (m as MemberSummary).name === 'string' &&
       typeof (m as MemberSummary).email === 'string'
     );
+  }
+
+  // ------------------- realtime handlers -------------------
+
+  /**
+   * Reconcile `MemberRemoved`: drop the user from the project's slice.
+   * Silent no-op if the slice is missing (dialog never opened for this id)
+   * or the user is already absent (AC11).
+   */
+  private onMemberRemoved(evt: MemberRemovedEvent): void {
+    if (!evt || typeof evt.projectId !== 'string' || typeof evt.userId !== 'string') {
+      return;
+    }
+    this.removeLocalMember(evt.projectId, evt.userId);
+  }
+
+  /**
+   * Reconcile `MemberAdded`. ⚠ The payload does not include `projectId`;
+   * attribution is done via the "current project context" set by the open
+   * members dialog. If no context is set, the event is dropped — per the
+   * documented best-effort behavior until the backend wraps the payload.
+   *
+   * Silent no-op when: no context; slice missing; user already in slice.
+   */
+  private onMemberAdded(evt: MemberAddedEvent): void {
+    if (!evt || typeof evt.userId !== 'string' || evt.userId.length === 0) {
+      return;
+    }
+    const projectId = this.contextSignal();
+    if (projectId === null) {
+      return;
+    }
+    const slice = this.getState().byProjectId[projectId];
+    if (slice === undefined) {
+      return;
+    }
+    if (slice.members.some(m => m.userId === evt.userId)) {
+      return;
+    }
+    const newMember: MemberSummary = {
+      userId: evt.userId,
+      name: evt.name,
+      email: evt.email,
+      role: evt.role,
+      joinedAt: evt.joinedAt
+    };
+    this.upsertSlice(projectId, { members: [...slice.members, newMember] });
+  }
+
+  private teardownRealtimeSubscriptions(): void {
+    for (const sub of this.realtimeSubscriptions) {
+      sub.unsubscribe();
+    }
+    this.realtimeSubscriptions = [];
   }
 }

--- a/KanbAI-Web/src/app/features/projects/state/project-state.service.spec.ts
+++ b/KanbAI-Web/src/app/features/projects/state/project-state.service.spec.ts
@@ -5,12 +5,61 @@ import {
   provideHttpClientTesting
 } from '@angular/common/http/testing';
 import { WritableSignal, signal } from '@angular/core';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { Subject } from 'rxjs';
 
 import { ProjectStateService } from './project-state.service';
 import { AuthService } from '../../../core/services/AuthService';
 import { UserProfileDto } from '../../../core/models/auth.models';
 import { ProjectSummary, ApiResponse } from '../models/project.model';
 import { environment } from '../../../../environments/environment';
+import {
+  SignalRConnectionState,
+  SignalRService
+} from '../../../core/services/signalr.service';
+import {
+  ProjectDeletedEvent,
+  ProjectUpdatedEvent,
+  REALTIME_EVENT
+} from '../../../core/models/realtime-events';
+
+interface MockSignalRService {
+  connectionState: WritableSignal<SignalRConnectionState>;
+  on: ReturnType<typeof vi.fn>;
+  emit<T>(name: string, payload: T): void;
+  joinProjectGroup: ReturnType<typeof vi.fn>;
+  leaveProjectGroup: ReturnType<typeof vi.fn>;
+  start: ReturnType<typeof vi.fn>;
+  stop: ReturnType<typeof vi.fn>;
+  _subjects: Map<string, Subject<unknown>>;
+}
+
+function createMockSignalRService(
+  initialState: SignalRConnectionState = 'disconnected'
+): MockSignalRService {
+  const subjects = new Map<string, Subject<unknown>>();
+  const connectionState = signal<SignalRConnectionState>(initialState);
+  const onFn = vi.fn((name: string) => {
+    let subject = subjects.get(name);
+    if (!subject) {
+      subject = new Subject<unknown>();
+      subjects.set(name, subject);
+    }
+    return subject.asObservable();
+  });
+  return {
+    connectionState,
+    on: onFn,
+    emit<T>(name: string, payload: T): void {
+      subjects.get(name)?.next(payload);
+    },
+    joinProjectGroup: vi.fn().mockResolvedValue(undefined),
+    leaveProjectGroup: vi.fn().mockResolvedValue(undefined),
+    start: vi.fn().mockResolvedValue(undefined),
+    stop: vi.fn().mockResolvedValue(undefined),
+    _subjects: subjects
+  };
+}
 
 const LIST_URL = `${environment.apiUrl}/project`;
 
@@ -36,9 +85,11 @@ describe('ProjectStateService', () => {
   let service: ProjectStateService;
   let httpMock: HttpTestingController;
   let currentUserSig: WritableSignal<UserProfileDto | null>;
+  let signalRMock: MockSignalRService;
 
   beforeEach(() => {
     currentUserSig = signal<UserProfileDto | null>(MOCK_USER);
+    signalRMock = createMockSignalRService('disconnected');
 
     TestBed.configureTestingModule({
       providers: [
@@ -59,12 +110,14 @@ describe('ProjectStateService', () => {
               currentUserSig.set(null);
             }
           }
-        }
+        },
+        { provide: SignalRService, useValue: signalRMock }
       ]
     });
 
     service = TestBed.inject(ProjectStateService);
     httpMock = TestBed.inject(HttpTestingController);
+    TestBed.flushEffects();
   });
 
   afterEach(() => {
@@ -636,6 +689,7 @@ describe('ProjectStateService', () => {
       // Fresh TestBed with currentUser=null from the start.
       TestBed.resetTestingModule();
       const unauthSig = signal<UserProfileDto | null>(null);
+      const unauthSignalR = createMockSignalRService('disconnected');
 
       TestBed.configureTestingModule({
         providers: [
@@ -650,7 +704,8 @@ describe('ProjectStateService', () => {
               register: () => undefined,
               logout: () => unauthSig.set(null)
             }
-          }
+          },
+          { provide: SignalRService, useValue: unauthSignalR }
         ]
       });
 
@@ -665,6 +720,247 @@ describe('ProjectStateService', () => {
       // No HTTP request was issued.
       const http = TestBed.inject(HttpTestingController);
       http.expectNone(LIST_URL);
+    });
+  });
+
+  describe('real-time events', () => {
+    /** Loads a seed list + transitions the connection to 'connected'. */
+    function seedAndConnect(seed: ProjectSummary[]): void {
+      service.loadProjects();
+      httpMock.expectOne(LIST_URL).flush({
+        success: true,
+        message: null,
+        errors: [],
+        data: seed
+      } satisfies ApiResponse<ProjectSummary[]>);
+      signalRMock.connectionState.set('connected');
+      TestBed.flushEffects();
+    }
+
+    describe('ProjectUpdated', () => {
+      it('replaces the matching entry in place on event arrival', () => {
+        const seed = [
+          makeProjectSummary({ id: 'p-1', name: 'One', updatedAt: '2026-04-10T00:00:00Z' }),
+          makeProjectSummary({ id: 'p-2', name: 'Two' })
+        ];
+        seedAndConnect(seed);
+
+        const evt: ProjectUpdatedEvent = {
+          projectId: 'p-1',
+          name: 'One (renamed)',
+          description: 'updated desc',
+          updatedAt: '2026-04-11T00:00:00Z'
+        };
+        signalRMock.emit(REALTIME_EVENT.ProjectUpdated, evt);
+
+        const ids = service.projects().map(p => p.id);
+        expect(ids).toEqual(['p-1', 'p-2']);
+        const updated = service.projects()[0];
+        expect(updated.name).toBe('One (renamed)');
+        expect(updated.description).toBe('updated desc');
+        expect(updated.updatedAt).toBe('2026-04-11T00:00:00Z');
+        // Role/createdAt preserved.
+        expect(updated.role).toBe('Owner');
+        expect(updated.createdAt).toBe(seed[0].createdAt);
+      });
+
+      it('is a silent no-op when the project is not in local state', () => {
+        seedAndConnect([makeProjectSummary({ id: 'p-1' })]);
+        const before = service.projects();
+
+        signalRMock.emit<ProjectUpdatedEvent>(REALTIME_EVENT.ProjectUpdated, {
+          projectId: 'p-unknown',
+          name: 'x',
+          description: null,
+          updatedAt: '2026-04-11T00:00:00Z'
+        });
+
+        // Same reference / same data; no mutation.
+        expect(service.projects()).toEqual(before);
+      });
+    });
+
+    describe('ProjectDeleted', () => {
+      it('removes the matching entry on event arrival', () => {
+        seedAndConnect([
+          makeProjectSummary({ id: 'p-1' }),
+          makeProjectSummary({ id: 'p-2' })
+        ]);
+
+        signalRMock.emit<ProjectDeletedEvent>(REALTIME_EVENT.ProjectDeleted, {
+          projectId: 'p-1'
+        });
+
+        expect(service.projects().map(p => p.id)).toEqual(['p-2']);
+      });
+
+      it('is a silent no-op when the project is already absent', () => {
+        seedAndConnect([makeProjectSummary({ id: 'p-1' })]);
+
+        signalRMock.emit<ProjectDeletedEvent>(REALTIME_EVENT.ProjectDeleted, {
+          projectId: 'p-missing'
+        });
+
+        expect(service.projects().map(p => p.id)).toEqual(['p-1']);
+      });
+    });
+
+    describe('auto Join / Leave group membership (Layer 1)', () => {
+      it('invokes joinProjectGroup for every seeded project on first connect', () => {
+        seedAndConnect([
+          makeProjectSummary({ id: 'p-1' }),
+          makeProjectSummary({ id: 'p-2' })
+        ]);
+
+        expect(signalRMock.joinProjectGroup).toHaveBeenCalledWith('p-1');
+        expect(signalRMock.joinProjectGroup).toHaveBeenCalledWith('p-2');
+        expect(signalRMock.joinProjectGroup).toHaveBeenCalledTimes(2);
+        expect(signalRMock.leaveProjectGroup).not.toHaveBeenCalled();
+      });
+
+      it('fires a Leave when a project is removed via ProjectDeleted', () => {
+        seedAndConnect([
+          makeProjectSummary({ id: 'p-1' }),
+          makeProjectSummary({ id: 'p-2' })
+        ]);
+        signalRMock.joinProjectGroup.mockClear();
+
+        signalRMock.emit<ProjectDeletedEvent>(REALTIME_EVENT.ProjectDeleted, {
+          projectId: 'p-1'
+        });
+        TestBed.flushEffects();
+
+        expect(signalRMock.leaveProjectGroup).toHaveBeenCalledWith('p-1');
+        expect(signalRMock.leaveProjectGroup).toHaveBeenCalledTimes(1);
+        expect(signalRMock.joinProjectGroup).not.toHaveBeenCalled();
+      });
+
+      it('re-joins all projects after a reconnect cycle', () => {
+        seedAndConnect([
+          makeProjectSummary({ id: 'p-1' }),
+          makeProjectSummary({ id: 'p-2' })
+        ]);
+        expect(signalRMock.joinProjectGroup).toHaveBeenCalledTimes(2);
+
+        // Simulate reconnect: connected → reconnecting → connected.
+        signalRMock.joinProjectGroup.mockClear();
+        signalRMock.leaveProjectGroup.mockClear();
+
+        signalRMock.connectionState.set('reconnecting');
+        TestBed.flushEffects();
+        signalRMock.connectionState.set('connected');
+        TestBed.flushEffects();
+
+        // Every project was re-joined; no Leave fired for ids that are
+        // still in the list.
+        expect(signalRMock.joinProjectGroup).toHaveBeenCalledWith('p-1');
+        expect(signalRMock.joinProjectGroup).toHaveBeenCalledWith('p-2');
+        expect(signalRMock.joinProjectGroup).toHaveBeenCalledTimes(2);
+        expect(signalRMock.leaveProjectGroup).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('Subscription teardown on disconnect (AC12 defense in depth)', () => {
+      it('stops reconciling ProjectUpdated after connectionState leaves connected', () => {
+        seedAndConnect([makeProjectSummary({ id: 'p-1', name: 'Original' })]);
+        // Baseline: event arrives while connected — state updates.
+        signalRMock.emit<ProjectUpdatedEvent>(REALTIME_EVENT.ProjectUpdated, {
+          projectId: 'p-1',
+          name: 'Live',
+          description: null,
+          updatedAt: '2026-04-11T00:00:00Z'
+        });
+        expect(service.projects()[0].name).toBe('Live');
+
+        // Disconnect: the effect should tear down subscribers.
+        signalRMock.connectionState.set('disconnected');
+        TestBed.flushEffects();
+
+        // Emit on the stale Subject — if teardown worked, the handler is
+        // gone and state is untouched.
+        signalRMock.emit<ProjectUpdatedEvent>(REALTIME_EVENT.ProjectUpdated, {
+          projectId: 'p-1',
+          name: 'Post-disconnect',
+          description: null,
+          updatedAt: '2026-04-12T00:00:00Z'
+        });
+        expect(service.projects()[0].name).toBe('Live');
+      });
+    });
+
+    describe('re-subscription after logout → login cycle', () => {
+      it('events arriving after a stop()/start() cycle still reconcile into state', () => {
+        // First connect cycle: seed, emit a successful event.
+        seedAndConnect([makeProjectSummary({ id: 'p-1', name: 'Before' })]);
+        signalRMock.emit<ProjectUpdatedEvent>(REALTIME_EVENT.ProjectUpdated, {
+          projectId: 'p-1',
+          name: 'After-first',
+          description: null,
+          updatedAt: '2026-04-11T00:00:00Z'
+        });
+        expect(service.projects()[0].name).toBe('After-first');
+
+        // Simulate logout: disconnect + reset the mock's subjects (the real
+        // SignalRService.stop() completes and discards them).
+        signalRMock.connectionState.set('disconnected');
+        TestBed.flushEffects();
+        signalRMock._subjects.clear();
+
+        // Simulate login: user reappears, a FRESH project list is loaded,
+        // and the connection transitions to 'connected'. A new Subject is
+        // minted by the mock `on` for each event; the service's effect
+        // must re-subscribe to those fresh Subjects.
+        currentUserSig.set(MOCK_USER);
+        service.loadProjects();
+        httpMock.expectOne(LIST_URL).flush({
+          success: true,
+          message: null,
+          errors: [],
+          data: [makeProjectSummary({ id: 'p-1', name: 'Before' })]
+        } satisfies ApiResponse<ProjectSummary[]>);
+        signalRMock.connectionState.set('connected');
+        TestBed.flushEffects();
+
+        // Emit an update on the NEW Subject.
+        signalRMock.emit<ProjectUpdatedEvent>(REALTIME_EVENT.ProjectUpdated, {
+          projectId: 'p-1',
+          name: 'After-second',
+          description: null,
+          updatedAt: '2026-04-12T00:00:00Z'
+        });
+
+        expect(service.projects()[0].name).toBe('After-second');
+      });
+    });
+
+    describe('Console hygiene', () => {
+      it('never logs the projectId in handler execution', () => {
+        const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+        const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+        seedAndConnect([makeProjectSummary({ id: 'secret-project-id' })]);
+        signalRMock.emit<ProjectUpdatedEvent>(REALTIME_EVENT.ProjectUpdated, {
+          projectId: 'secret-project-id',
+          name: 'x',
+          description: null,
+          updatedAt: '2026-04-11T00:00:00Z'
+        });
+        signalRMock.emit<ProjectDeletedEvent>(REALTIME_EVENT.ProjectDeleted, {
+          projectId: 'secret-project-id'
+        });
+
+        const allArgs = [
+          ...consoleLogSpy.mock.calls.flat(),
+          ...consoleErrorSpy.mock.calls.flat()
+        ];
+        for (const arg of allArgs) {
+          const asString = typeof arg === 'string' ? arg : JSON.stringify(arg);
+          expect(asString).not.toContain('secret-project-id');
+        }
+
+        consoleLogSpy.mockRestore();
+        consoleErrorSpy.mockRestore();
+      });
     });
   });
 });

--- a/KanbAI-Web/src/app/features/projects/state/project-state.service.ts
+++ b/KanbAI-Web/src/app/features/projects/state/project-state.service.ts
@@ -1,9 +1,10 @@
-import { Injectable, Signal, effect, inject } from '@angular/core';
+import { DestroyRef, Injectable, Signal, effect, inject } from '@angular/core';
 import { Observable, Subscription, throwError } from 'rxjs';
 import { catchError, tap } from 'rxjs/operators';
 
 import { BaseStateService } from '../../../core/state/base-state.service';
 import { AuthService } from '../../../core/services/AuthService';
+import { SignalRService } from '../../../core/services/signalr.service';
 import { ProjectSummary } from '../models/project.model';
 import {
   INITIAL_PROJECT_STATE,
@@ -14,6 +15,11 @@ import {
   ProjectsApiService,
   mapErrorToUserMessage
 } from '../services/projects-api.service';
+import {
+  ProjectDeletedEvent,
+  ProjectUpdatedEvent,
+  REALTIME_EVENT
+} from '../../../core/models/realtime-events';
 
 /**
  * Single source of truth for the authenticated user's project list.
@@ -40,6 +46,8 @@ import {
 export class ProjectStateService extends BaseStateService<ProjectState> {
   private readonly projectsApi = inject(ProjectsApiService);
   private readonly authService = inject(AuthService);
+  private readonly signalRService = inject(SignalRService);
+  private readonly destroyRef = inject(DestroyRef);
 
   /**
    * Subscription reference for the in-flight `loadProjects()` call, used
@@ -47,6 +55,22 @@ export class ProjectStateService extends BaseStateService<ProjectState> {
    * the user logs out mid-request.
    */
   private inFlightLoad: Subscription | null = null;
+
+  /**
+   * Active real-time event subscriptions. Refreshed on every
+   * `connectionState → 'connected'` transition so the fresh Subjects
+   * handed out by `SignalRService.on()` after a `stop()`/`start()` cycle
+   * (e.g. logout → login) are actually wired up.
+   */
+  private realtimeSubscriptions: Subscription[] = [];
+
+  /**
+   * Project ids currently represented as a SignalR group membership on the
+   * server. Maintained by the auto-join/leave effect below. Cleared on
+   * disconnect (server wipes group membership anyway; we re-join from
+   * scratch on reconnect).
+   */
+  private readonly joinedProjectIds = new Set<string>();
 
   // Public selectors — read-only signals exposed to the rest of the app.
   readonly projects: Signal<ProjectSummary[]> = this.select(state => state.projects);
@@ -66,6 +90,59 @@ export class ProjectStateService extends BaseStateService<ProjectState> {
         this.reset();
       }
     });
+
+    // Real-time subscriber (re-)registration. Re-runs whenever
+    // connectionState changes: on 'connected' we wire fresh subscribers
+    // against the fresh Subjects the transport handed out after the most
+    // recent `stop()`/`start()`. On any other state we tear down so we
+    // don't leak Subject references across cycles.
+    effect(() => {
+      const state = this.signalRService.connectionState();
+      if (state !== 'connected') {
+        this.teardownRealtimeSubscriptions();
+        return;
+      }
+      this.teardownRealtimeSubscriptions();
+      this.realtimeSubscriptions.push(
+        this.signalRService
+          .on<ProjectUpdatedEvent>(REALTIME_EVENT.ProjectUpdated)
+          .subscribe(evt => this.onProjectUpdated(evt))
+      );
+      this.realtimeSubscriptions.push(
+        this.signalRService
+          .on<ProjectDeletedEvent>(REALTIME_EVENT.ProjectDeleted)
+          .subscribe(evt => this.onProjectDeleted(evt))
+      );
+    });
+
+    // Layer-1 auto-join/leave (see tech spec §"Join strategy — two layers").
+    // Diffs `projects()` against `joinedProjectIds`; fires Join for newly
+    // desired ids and Leave for no-longer-desired ids. Runs only while
+    // connected — on disconnect the local tracking set is cleared so a
+    // subsequent reconnect re-joins everything from scratch.
+    effect(() => {
+      const connected = this.signalRService.connectionState() === 'connected';
+      if (!connected) {
+        this.joinedProjectIds.clear();
+        return;
+      }
+      const desired = new Set(this.projects().map(p => p.id));
+
+      for (const id of desired) {
+        if (!this.joinedProjectIds.has(id)) {
+          void this.signalRService.joinProjectGroup(id);
+          this.joinedProjectIds.add(id);
+        }
+      }
+      for (const id of Array.from(this.joinedProjectIds)) {
+        if (!desired.has(id)) {
+          void this.signalRService.leaveProjectGroup(id);
+          this.joinedProjectIds.delete(id);
+        }
+      }
+    });
+
+    this.destroyRef.onDestroy(() => this.teardownRealtimeSubscriptions());
   }
 
   protected getInitialState(): ProjectState {
@@ -202,5 +279,56 @@ export class ProjectStateService extends BaseStateService<ProjectState> {
       this.inFlightLoad = null;
     }
     this.replaceState(INITIAL_PROJECT_STATE);
+  }
+
+  // ------------------- realtime handlers -------------------
+
+  /**
+   * Reconcile `ProjectUpdated`: replace-in-place by projectId.
+   * Silent no-op if the project is not in the local list (AC11).
+   */
+  private onProjectUpdated(evt: ProjectUpdatedEvent): void {
+    if (!evt || typeof evt.projectId !== 'string') {
+      return;
+    }
+    const current = this.getState().projects;
+    const index = current.findIndex(p => p.id === evt.projectId);
+    if (index === -1) {
+      return;
+    }
+    const updated: ProjectSummary = {
+      ...current[index],
+      name: evt.name,
+      description: evt.description,
+      updatedAt: evt.updatedAt
+    };
+    const next = [
+      ...current.slice(0, index),
+      updated,
+      ...current.slice(index + 1)
+    ];
+    this.setState({ projects: next });
+  }
+
+  /**
+   * Reconcile `ProjectDeleted`: filter out the matching id.
+   * Silent no-op if the project is absent (AC11).
+   */
+  private onProjectDeleted(evt: ProjectDeletedEvent): void {
+    if (!evt || typeof evt.projectId !== 'string') {
+      return;
+    }
+    const current = this.getState().projects;
+    const next = current.filter(p => p.id !== evt.projectId);
+    if (next.length !== current.length) {
+      this.setState({ projects: next });
+    }
+  }
+
+  private teardownRealtimeSubscriptions(): void {
+    for (const sub of this.realtimeSubscriptions) {
+      sub.unsubscribe();
+    }
+    this.realtimeSubscriptions = [];
   }
 }

--- a/docs/handoffs/issue_46_context.md
+++ b/docs/handoffs/issue_46_context.md
@@ -1,0 +1,107 @@
+# Feature: Integrate Real-time Events with State Management
+
+**GitHub Issue:** #46
+**Milestone:** Real-time UI Updates & Kanban Interaction (Milestone #5)
+**Assignee:** Gulybi
+
+## Business Value
+
+**Who is this for?**
+End users of the KanbAI Kanban board — project owners and project members — who collaborate on the same project in parallel, often from different devices or browser sessions.
+
+**Why is it valuable?**
+Issue #45 delivered a live SignalR transport in the browser, but nothing in the app currently consumes the events flowing over that transport. From the user's perspective the product is still indistinguishable from the pre-SignalR version: the wire is open, yet the UI never moves on its own. Until the real-time transport is connected to the Angular Signals-based state services, a user has no way of knowing that a teammate moved a card, added a member, created a column, or deleted a project — short of manually refreshing the page.
+
+**What problem does it solve?**
+This issue closes the loop between transport (#45) and the visible UI. It delivers the behavior end users actually perceive as "real-time collaboration": when another user (or the backend itself) causes a change on a board you are viewing, that change appears in your UI within a couple of seconds without any interaction on your part. It is also the prerequisite that #47 (visual drag-and-drop with optimistic updates) depends on — without reactive state reconciliation, an optimistic client move cannot be safely confirmed or reverted by the server's authoritative `TaskMoved` broadcast.
+
+**Business impact:**
+- Turns the previously invisible SignalR channel into a visible product capability — multi-user collaboration without manual refresh.
+- Unblocks issue #47 (visual drag-and-drop with optimistic UI) by providing the server-confirmation path an optimistic update needs.
+- Establishes the event-to-state reconciliation pattern once, so future real-time features (notifications, AI agent activity, comments) inherit the same wiring instead of each reinventing it.
+- Protects the shared-state promise of a Kanban tool: users making decisions based on the board can trust the board actually reflects reality.
+
+## Current State
+
+- SignalR transport is fully wired as of PR #45 and lives at `KanbAI-Web/src/app/core/services/signalr.service.ts`. It exposes `start()`, `stop()`, `on<T>(eventName)`, and a read-only `connectionState` signal. It opens a single connection per authenticated session via an `effect()` on `AuthStateService.isAuthenticated`, and closes on logout.
+- No file in the Angular app subscribes to `SignalRService.on(...)` today. A search across `KanbAI-Web/src/app` for the server event names documented in the API map (`TaskMoved`, `TaskCreated`, `ColumnCreated`, `ColumnDeleted`, `ProjectUpdated`, `ProjectDeleted`, `MemberAdded`, `MemberRemoved`) returns zero subscribers.
+- No component or service currently calls the hub methods `JoinProjectGroup` / `LeaveProjectGroup` that the backend requires before broadcasts are delivered (see `backend_api_map.md`). Today a user opening the board would receive zero server pushes even though the connection is up, because the connection never joins the relevant project group.
+- The board route (`/board`) and its component at `KanbAI-Web/src/app/features/board/board-page/board-page.component.ts` exist but are an empty shell — no task data, no columns, no state service of their own yet. Any board-specific kanban state (tasks, columns) is not yet modeled in the frontend.
+- The project list is owned by `KanbAI-Web/src/app/features/projects/state/project-state.service.ts` (extends `BaseStateService`, exposes `projects`, `isLoading`, `error`, `hasLoaded`). The member list is owned by `KanbAI-Web/src/app/features/projects/state/members-state.service.ts`. Both are populated strictly by HTTP CRUD through their `*-api.service.ts` siblings; neither receives pushed updates. So when a teammate renames a project you can currently see in the dashboard, or another owner removes a member in a dialog you have open, your UI keeps the stale name / stale member until refresh.
+- Net user-visible behavior today: the app behaves as a single-user app despite having a live WebSocket. Open the dashboard in two tabs, rename a project in tab A — tab B shows the old name until reloaded.
+
+## Desired State
+
+After this issue is delivered, server-originated changes must flow into the app's Signals-based state within seconds of being broadcast, with no user interaction.
+
+**Expected behaviors (UI-observable):**
+- While a user is viewing the dashboard, if another user (or another of the same user's sessions) renames or deletes a project the current user can see, the displayed project card updates or disappears automatically within ~2 seconds of the server broadcast, without a refresh.
+- While a user is viewing the members dialog for a project, if another owner adds or removes a member of that project, the member list in the dialog updates automatically within ~2 seconds, without a refresh.
+- When a user navigates to the board view for a specific project, the app automatically joins that project's broadcast group so task/column events for that project start reaching this client. When the user navigates away from the board, the app leaves the group so we stop receiving events for a project the user is no longer viewing.
+- While a user is viewing a board, if another user moves a task, creates a task, creates a column, or deletes a column for that project, the board view reflects the change automatically within ~2 seconds, without a refresh.
+- If the real-time channel is temporarily disconnected (e.g., wifi blip) and then reconnects (this recovery is already handled by #45), any missed events between the drop and the reconnect are allowed to be lost in this issue — a future issue may add a resync-on-reconnect flow. What MUST hold: once reconnected, new events resume landing in state as normal.
+- Events for projects the user is not currently interested in (not a member of, or not currently joined to) must not alter the local state. The guard here is that the backend only broadcasts to `project_{projectId}` groups the client has joined, and the client only joins a group when the user is on that project's board.
+- Events received for entities the client does not currently have in state (e.g., a `TaskMoved` for a board the user is not viewing, or a `MemberRemoved` for a project whose members dialog is closed) must not crash the app, must not create uncaught errors in the console, and must simply be ignored.
+
+**Expected user flow:**
+1. User A and User B are both logged into KanbAI and are both members of Project X.
+2. Both users have the dashboard open. User A renames Project X. Within ~2 seconds User B sees the renamed project card update in place — no refresh.
+3. User B navigates to Project X's board. The app calls `JoinProjectGroup(X)` on the hub automatically.
+4. User A moves a task from column "To Do" to column "In Progress". Within ~2 seconds User B sees that task disappear from "To Do" and appear in "In Progress" on his open board — no refresh. (The visual drag-and-drop itself is #47; this ticket only requires the state-side reconciliation.)
+5. User B navigates away from the board back to the dashboard. The app calls `LeaveProjectGroup(X)` so further task-level broadcasts for Project X no longer reach User B.
+6. User A deletes Project X. Within ~2 seconds User B's dashboard removes the Project X card — no refresh.
+
+**Out of scope for this issue (belongs elsewhere):**
+- Visual drag-and-drop interaction and optimistic updates — #47.
+- Introducing a board-level kanban state service populated from the backend (fetching tasks/columns for a project) is out of scope unless it is strictly necessary to deliver the board-event subscriptions above; if the board component is still an empty shell at implementation time, at minimum the `Join` / `Leave` lifecycle and the event-to-state reconciliation hooks must be in place and ready, even if the board UI consuming them is populated in #47.
+- Backfilling lost events after a reconnect — future issue.
+- Any UI connection-status indicator (the `connectionState` signal exists, but no component needs to render it for this ticket).
+- Rewriting `AuthStateService`, `SignalRService`, or `BaseStateService`.
+
+## Milestone Context
+
+**Milestone:** #5 — Real-time UI Updates & Kanban Interaction
+
+**Prerequisite Issues:**
+- #45 — Setup SignalR Client Service — **CLOSED**. Delivers `SignalRService` with `on<T>()`, `start()`, `stop()`, and `connectionState`. Without this, there is no event stream to subscribe to.
+- Authentication flow (earlier PRs including #60) — **CLOSED**. The hub connection only exists for authenticated users; state reconciliation therefore only runs while authenticated. Already satisfied.
+- HTTP CRUD for projects and members (issues #27–#33 era) — **CLOSED**. The state services (`ProjectStateService`, `MembersStateService`) this ticket integrates with already exist and own the canonical local state.
+
+**Downstream Issues (blocked by this one):**
+- #47 — Implement Visual Drag-and-Drop (Angular CDK) — **OPEN**. Optimistic drag-and-drop needs a reliable server-confirmation path: when the client-side move completes and the backend broadcasts `TaskMoved`, this ticket's reconciliation logic is what lets the optimistic update be confirmed or corrected without the UI feeling stuck. #47 cannot be delivered cleanly until #46 lands.
+- #48 — Document AI Frontend Real-time Logic (`AI_LOGS.md`) — **CLOSED** already per the milestone list, but its contents are expected to describe the flow this ticket introduces.
+
+**Related Work:**
+- `docs/handoffs/issue_45_context.md` and `docs/handoffs/issue_45_tech_spec.md` describe the transport layer this issue consumes.
+- `.claude/backend_api_map.md` is authoritative for the server event names, payload shapes, and the `JoinProjectGroup` / `LeaveProjectGroup` hub methods. Eight server-to-client events are defined: `ProjectUpdated`, `ProjectDeleted`, `MemberAdded`, `MemberRemoved`, `ColumnCreated`, `ColumnDeleted`, `TaskCreated`, `TaskMoved`. Any event the frontend subscribes to in this issue must match the name and payload in that document.
+- The backend explicitly does NOT broadcast `ProjectCreated` (the group for a brand-new project does not yet exist at creation time). A user who just had themselves added to a newly created project will only see it on their next `GET /api/project`. This is a product constraint for this issue: the frontend must not invent a `ProjectCreated` subscriber that silently never fires.
+- The board route (`/board`) is a shell today; any board-level state integration this issue needs must be coordinated with whatever #47 introduces, to avoid duplicate state services.
+
+## Acceptance Criteria
+
+- [ ] When a logged-in user is viewing the dashboard and a `ProjectUpdated` event arrives for a project in their local list, the corresponding project card in the UI reflects the updated name/description within 2 seconds of event arrival, without a manual refresh.
+- [ ] When a logged-in user is viewing the dashboard and a `ProjectDeleted` event arrives for a project in their local list, that project card disappears from the grid within 2 seconds of event arrival, without a manual refresh.
+- [ ] When the members dialog is open for a project and a `MemberAdded` event arrives for that project, the new member appears in the dialog's member list within 2 seconds without closing/reopening the dialog.
+- [ ] When the members dialog is open for a project and a `MemberRemoved` event arrives for that project, the removed member is no longer displayed in the dialog's member list within 2 seconds without closing/reopening the dialog.
+- [ ] When a user navigates to the board view for a specific project, the SignalR hub method `JoinProjectGroup` is invoked exactly once with that project's id, verifiable in the browser DevTools WebSocket frames panel; when the user navigates away from the board, `LeaveProjectGroup` is invoked exactly once with the same project id.
+- [ ] When a user is on a board and a `TaskMoved` event arrives for the currently viewed project, the referenced task's column and order reflect the event payload within 2 seconds without a refresh; if the referenced task is not present in local state, the UI does not throw, does not log an uncaught error, and continues to function.
+- [ ] When a user is on a board and a `TaskCreated` event arrives for the currently viewed project, the new task appears in its column within 2 seconds without a refresh.
+- [ ] When a user is on a board and a `ColumnCreated` event arrives for the currently viewed project, the new column appears in the board within 2 seconds without a refresh.
+- [ ] When a user is on a board and a `ColumnDeleted` event arrives for the currently viewed project, the referenced column is removed from the board within 2 seconds without a refresh.
+- [ ] Events received for a project the client has not joined (e.g., stale group membership after a reconnect, or any event for an unrelated project) do not mutate local state and do not produce uncaught errors in the browser console.
+- [ ] An event whose payload references an entity not currently present in local state (e.g., `MemberRemoved` for a user not in the local member list, `TaskMoved` for an unknown task id) is silently ignored — the UI does not throw, the console has no uncaught error, and the operation is a no-op against local state.
+- [ ] When the user logs out, subscriptions the app holds on `SignalRService.on(...)` are torn down in the same logout cycle, verifiable by the absence of post-logout subscriber activity; this is satisfied once `SignalRService.stop()` has completed (already contracted by #45) and no downstream consumer attempts to continue reading from stale event streams.
+- [ ] No payload field, no JWT, and no user id is written to `console.log` by any event handler introduced in this issue, in keeping with the project's logging/privacy standard.
+- [ ] `npm run build` completes successfully with the new event integration in place.
+- [ ] `npm run test -- --watch=false` runs to completion; any test failures tied to the newly introduced event handlers are fixed before the issue is considered done (pre-existing failures unrelated to real-time state integration are documented, not fixed, per project policy).
+
+### Quality Gate Check
+
+Each criterion above has been reviewed for:
+- **Observable:** every item can be verified either in the browser (DevTools Console, DevTools WebSocket-frames panel, visible UI changes on a dashboard / members dialog / board) or via build/test command exit status. No criterion depends on internal framework state invisible to QA.
+- **Specific:** concrete events (by the exact name in `backend_api_map.md`), concrete surfaces (dashboard card, members dialog row, board column), and concrete latency bound (within 2 seconds of event arrival) are named; no vague terms like "responsive" or "smooth".
+- **Testable:** QA can drive each scenario deterministically by using two browser sessions (or triggering backend mutations via the API), asserting on a visible outcome and on the absence of console errors.
+
+---
+
+*"The business context is defined and saved. You can now instruct the staff-engineer agent to read the context note and design the frontend technical specification."*

--- a/docs/handoffs/issue_46_tech_spec.md
+++ b/docs/handoffs/issue_46_tech_spec.md
@@ -1,0 +1,908 @@
+# Technical Specification: Integrate Real-time Events with State Management
+
+**Context Document:** [issue_46_context.md](./issue_46_context.md)
+**GitHub Issue:** #46
+**Milestone:** #5 — Real-time UI Updates & Kanban Interaction
+**Depends on:** #45 (SignalR transport) — DONE
+
+## Overview
+
+This ticket wires the already-live SignalR transport to the Signals-based state services so that server-originated mutations appear in the UI within ~2 seconds without a refresh. Three state services are involved: `ProjectStateService` reconciles `ProjectUpdated` / `ProjectDeleted`; `MembersStateService` reconciles `MemberAdded` / `MemberRemoved`; a new `BoardStateService` reconciles `ColumnCreated` / `ColumnDeleted` / `TaskCreated` / `TaskMoved` and owns the `JoinProjectGroup` / `LeaveProjectGroup` lifecycle tied to board navigation. `SignalRService` is extended with two additive hub-invocation methods so consumers never call the underlying `HubConnection.invoke(...)` directly. The board route becomes parameterized (`/board/:projectId`) so the project id for Join/Leave is available from the URL; the empty `BoardPageComponent` shell picks up that param in `ngOnInit` and drives the lifecycle through `BoardStateService`.
+
+Because the `ProjectStateService` and `MembersStateService` subscribers must survive logout → login cycles (the transport completes its event subjects on `stop()`), every real-time subscriber re-registers via an `effect()` on `SignalRService.connectionState` rather than in the constructor.
+
+---
+
+## Component Architecture
+
+### Routing
+
+**Modified route:**
+
+| Path | Component | Guard | Description |
+|------|-----------|-------|-------------|
+| `/board/:projectId` | BoardPageComponent | authGuard | Board view for a specific project — drives Join/Leave lifecycle |
+
+**Route Configuration (replace the existing `/board` entry in [app.routes.ts](../../KanbAI-Web/src/app/app.routes.ts)):**
+```typescript
+{
+  path: 'board/:projectId',
+  loadComponent: () =>
+    import('./features/board/board-page/board-page.component').then(m => m.BoardPageComponent),
+  canActivate: [authGuard]
+}
+```
+
+The `path: 'board'` entry is replaced, not kept. Any existing test / navigation to `'/board'` without a project id is updated in the implementation steps. The wildcard fallback stays unchanged.
+
+### Component Hierarchy
+
+**Smart Components (Containers — modified):**
+- `BoardPageComponent` ([features/board/board-page/board-page.component.ts](../../KanbAI-Web/src/app/features/board/board-page/board-page.component.ts)) — reads `projectId` from `ActivatedRoute`, calls `boardStateService.enterBoard(projectId)` in `ngOnInit`, and `boardStateService.leaveBoard()` in `ngOnDestroy`. Still a UI shell — it does NOT render columns or tasks in this ticket (that is #47).
+
+**Services (new):**
+- `BoardStateService` ([features/board/state/board-state.service.ts](../../KanbAI-Web/src/app/features/board/state/board-state.service.ts)) — owns local kanban state (`columns`, `tasksByColumnId`, `currentProjectId`), drives Join/Leave through `SignalRService`, and reconciles the four board-scope events into state.
+
+**Services (modified — existing):**
+- `ProjectStateService` ([features/projects/state/project-state.service.ts](../../KanbAI-Web/src/app/features/projects/state/project-state.service.ts)) — gains a real-time subscriber that reconciles `ProjectUpdated` / `ProjectDeleted` into the existing `projects` signal. Also manages auto-join/auto-leave of project groups to match the current project list, so project-scope and member-scope events flow even when the user is not on a board. See [Join strategy](#join-strategy-two-layers).
+- `MembersStateService` ([features/projects/state/members-state.service.ts](../../KanbAI-Web/src/app/features/projects/state/members-state.service.ts)) — gains a real-time subscriber that reconciles `MemberAdded` / `MemberRemoved` into the per-project slice.
+- `SignalRService` ([core/services/signalr.service.ts](../../KanbAI-Web/src/app/core/services/signalr.service.ts)) — **additive only**: two new public methods `joinProjectGroup(projectId)` and `leaveProjectGroup(projectId)`. Existing API (`on`, `start`, `stop`, `connectionState`) is untouched. The interface `SignalRServiceContract` is extended with the two methods.
+
+### New Files to Create
+- `src/app/features/board/state/board-state.service.ts`
+- `src/app/features/board/state/board-state.service.spec.ts`
+- `src/app/features/board/state/board-state.model.ts`
+- `src/app/core/models/realtime-events.ts` — typed server-event DTO declarations
+- `src/app/features/projects/state/project-state.realtime.spec.ts` — (optional; see Test Strategy) new spec file or add describe-block to existing `project-state.service.spec.ts`
+- `src/app/features/projects/state/members-state.realtime.spec.ts` — same pattern
+
+### Files to Modify
+- `src/app/app.routes.ts` — replace `path: 'board'` with `path: 'board/:projectId'`
+- `src/app/app.routes.spec.ts` — update all `/board` navigations to `/board/{id}`
+- `src/app/core/services/signalr.service.ts` — add `joinProjectGroup` / `leaveProjectGroup`; extend `SignalRServiceContract`
+- `src/app/core/services/signalr.service.spec.ts` — add tests for the new methods (including "queued when disconnected" and "invoked once connected")
+- `src/app/features/projects/state/project-state.service.ts` — add real-time subscribers + auto-join/leave effect
+- `src/app/features/projects/state/project-state.service.spec.ts` — add real-time describe-block (provide mock `SignalRService` with test-controlled `Subject`s)
+- `src/app/features/projects/state/members-state.service.ts` — add real-time subscribers
+- `src/app/features/projects/state/members-state.service.spec.ts` — add real-time describe-block
+- `src/app/features/board/board-page/board-page.component.ts` — read route param, drive Join/Leave via `BoardStateService`
+- `src/app/features/board/board-page/board-page.component.spec.ts` — update and add tests covering ngOnInit/ngOnDestroy
+- `src/app/features/projects/components/project-card/project-card.component.*` — if it navigates to `/board`, update to `/board/{project.id}` (verify during implementation; out-of-scope if no such link exists yet)
+
+---
+
+## State & Data Layer
+
+### TypeScript Interfaces — Realtime Event DTOs
+
+**File:** `src/app/core/models/realtime-events.ts`
+
+Payload shapes mirror the backend `MemberRemovedEventDto`, `ColumnDeletedEventDto`, `TaskMovedEventDto`, `ProjectUpdatedEventDto`, `ProjectDeletedEventDto`, and the re-used response DTOs (`MemberResponseDto`, `ColumnResponseDto`, `TaskResponseDto`). All properties are camelCase — matches ASP.NET Core JSON default; confirmed in `backend_api_map.md`.
+
+```typescript
+// Event names — string-literal constants used to subscribe via SignalRService.on<T>(NAME).
+// Kept as a single source of truth so typos can't drift between subscribers.
+export const REALTIME_EVENT = {
+  ProjectUpdated: 'ProjectUpdated',
+  ProjectDeleted: 'ProjectDeleted',
+  MemberAdded: 'MemberAdded',
+  MemberRemoved: 'MemberRemoved',
+  ColumnCreated: 'ColumnCreated',
+  ColumnDeleted: 'ColumnDeleted',
+  TaskCreated: 'TaskCreated',
+  TaskMoved: 'TaskMoved'
+} as const;
+export type RealtimeEventName = typeof REALTIME_EVENT[keyof typeof REALTIME_EVENT];
+
+export interface ProjectUpdatedEvent {
+  projectId: string;
+  name: string;
+  description: string | null;
+  updatedAt: string; // ISO-8601
+}
+
+export interface ProjectDeletedEvent {
+  projectId: string;
+}
+
+// ⚠ BACKEND CAVEAT: MemberAdded is broadcast with the raw MemberResponseDto
+// — no projectId. Attribution is done from the "current dialog context"
+// (MembersStateService.currentProjectContext signal). See Known Backend
+// Contract Caveats section.
+export interface MemberAddedEvent {
+  userId: string;
+  name: string;
+  email: string;
+  role: string;
+  joinedAt: string; // ISO-8601
+}
+
+export interface MemberRemovedEvent {
+  userId: string;
+  projectId: string;
+}
+
+// ⚠ BACKEND CAVEAT: ColumnCreated payload carries projectId directly.
+export interface ColumnCreatedEvent {
+  id: string;
+  name: string;
+  colorCode: string | null;
+  columnOrder: number;
+  projectId: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ColumnDeletedEvent {
+  columnId: string;
+  projectId: string;
+}
+
+// ⚠ BACKEND CAVEAT: TaskCreated payload is TaskResponseDto — no projectId.
+// Attribution is done via BoardStateService.currentProjectId + the group
+// the client is joined to (the only reason this event arrives at all).
+export interface TaskCreatedEvent {
+  id: string;
+  title: string;
+  content: string | null;
+  taskOrder: number;
+  columnId: string;
+  assignedId: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface TaskMovedEvent {
+  taskId: string;
+  oldColumnId: string;
+  newColumnId: string;
+  oldTaskOrder: number;
+  newTaskOrder: number;
+  task: TaskCreatedEvent; // full post-move TaskResponseDto
+}
+```
+
+### BoardStateService Model
+
+**File:** `src/app/features/board/state/board-state.model.ts`
+
+```typescript
+import { ColumnResponseDto, TaskResponseDto } from '../../../core/models/realtime-events';
+
+// ColumnResponseDto / TaskResponseDto are re-exported from realtime-events.ts
+// for this ticket. When #47 lands and introduces HTTP-side DTOs, migrate to a
+// shared models folder.
+
+export interface BoardColumn {
+  id: string;
+  name: string;
+  colorCode: string | null;
+  columnOrder: number;
+  projectId: string;
+}
+
+export interface BoardTask {
+  id: string;
+  title: string;
+  content: string | null;
+  taskOrder: number;
+  columnId: string;
+  assignedId: string | null;
+}
+
+export interface BoardState {
+  /** projectId the user is currently viewing, set by `enterBoard(id)`. */
+  currentProjectId: string | null;
+  /** Columns belonging to the current project, ordered by columnOrder. */
+  columns: BoardColumn[];
+  /** Tasks indexed by columnId, ordered by taskOrder within each column. */
+  tasksByColumnId: Record<string, BoardTask[]>;
+}
+
+export const INITIAL_BOARD_STATE: BoardState = {
+  currentProjectId: null,
+  columns: [],
+  tasksByColumnId: {}
+};
+```
+
+> **Note on initial population:** Per context ("introducing a board-level kanban state service populated from the backend is out of scope unless strictly necessary"), `columns` and `tasksByColumnId` are NOT fetched via HTTP in this ticket. They start empty. Column/task events reconcile **against whatever is in state**, which in this ticket is always empty unless a preceding event populated it. This is intentional: the reconciliation paths are exercised and tested, but the visible board UI comes in #47 alongside the HTTP load.
+
+### State Management Strategy
+
+**Local state (Signals):** `BoardStateService` uses `BaseStateService` — same pattern as `ProjectStateService` / `MembersStateService`. Public selectors: `currentProjectId`, `columns`, `tasksByColumnId`.
+
+**Real-time subscription pattern (critical):** Every subscriber re-registers on connection. The shape is:
+
+```typescript
+// Inside each state service constructor (pseudocode — see implementation steps):
+effect(() => {
+  const state = this.signalRService.connectionState();
+  if (state === 'connected') {
+    // teardown previous bag, subscribe fresh
+    this.subscriptionBag.forEach(s => s.unsubscribe());
+    this.subscriptionBag = [];
+    this.subscriptionBag.push(
+      this.signalRService.on<ProjectUpdatedEvent>(REALTIME_EVENT.ProjectUpdated)
+        .subscribe(evt => this.onProjectUpdated(evt))
+    );
+    // …one push per event name
+  }
+});
+```
+
+Why a connection-state effect and not `takeUntilDestroyed()` alone: `SignalRService.stop()` (called on logout) completes every event subject and clears the internal map. A `takeUntilDestroyed()` subscription lives for the whole session, but the Observable underneath it completes on logout and the subscriber will never re-receive events after the next login. Re-registering whenever state transitions to `'connected'` restores event flow on post-logout logins.
+
+The `subscriptionBag` is torn down also when the service itself is destroyed (via `DestroyRef`) — defense in depth; `providedIn: 'root'` services live for the app lifetime, but the pattern is the same one used elsewhere in the codebase.
+
+### Join strategy — two layers
+
+**Layer 1 — `ProjectStateService` auto-joins all projects in the user's list.**
+Whenever `this.projects()` changes (after a successful `loadProjects()` or CRUD mutation), the service diffs the new list against the previously joined set and invokes `joinProjectGroup(id)` for newly added ids, `leaveProjectGroup(id)` for removed ids. Also re-joins on reconnect (on the `connectionState === 'connected'` effect run). On logout / token clear, all joined groups are forgotten locally — SignalR cleans up group membership automatically on disconnect, so no explicit leave is required on logout.
+
+This layer is what makes the dashboard and members-dialog ACs ("while viewing the dashboard a ProjectUpdated event arrives…") deliverable. Without it, the client would be in no project groups while on the dashboard.
+
+**Layer 2 — `BoardPageComponent` explicitly invokes Join/Leave for the viewed board.**
+This is redundant with Layer 1 for projects the user is already in (SignalR's `Groups.AddToGroupAsync` is idempotent on server side), but satisfies the AC literal ("`JoinProjectGroup` is invoked exactly once with that project's id" on board navigation) and is verifiable in DevTools WebSocket frames.
+
+**Leave semantics (important):** On board exit we invoke `LeaveProjectGroup` ONLY IF the project id is NOT in the user's current project list. If it IS in the list (typical case — they're a member of the project they viewed), Layer 1 still wants them in the group. So `BoardStateService.leaveBoard()` calls `signalRService.leaveProjectGroup(id)` **only when the project id is not present in `projectStateService.projects()`** — i.e., the user viewed a project they no longer own/belong to (rare; e.g., they were removed mid-session). In the common case the Layer-2 leave is suppressed because Layer 1 wants the group retained.
+
+> **AC literal vs. user-correct behavior — decision:** The AC says "`LeaveProjectGroup` is invoked exactly once with the same project id" on board exit. Invoking it naively would break the dashboard AC ("while viewing the dashboard a ProjectUpdated event arrives"). The chosen behavior satisfies the **spirit** of the AC (leave when no longer interested) over the **letter** (always leave on exit). This is documented here so QA can validate accordingly; if the literal interpretation is required, escalate.
+
+---
+
+## Service Integration
+
+### SignalRService — additive public surface
+
+**File:** `src/app/core/services/signalr.service.ts`
+
+Extend the existing `SignalRServiceContract` and add two methods. Signatures:
+
+```typescript
+export interface SignalRServiceContract {
+  readonly connectionState: Signal<SignalRConnectionState>;
+  start(): Promise<void>;
+  stop(): Promise<void>;
+  on<T>(eventName: string): Observable<T>;
+
+  /**
+   * Invokes the server hub method `JoinProjectGroup(projectId)` once the
+   * connection is `'connected'`. If called before start() completes, the
+   * call is queued and re-issued on transition to `'connected'`. If called
+   * while `'disconnected'`, returns a resolved Promise (no-op) — the
+   * connection-state effect in the state services will re-trigger joins
+   * on reconnect.
+   *
+   * Errors from the underlying `connection.invoke` (e.g., the backend
+   * throws HubException on malformed id) are caught and logged via
+   * console.error; no payload fields are logged. Does not reject the
+   * returned Promise so a caller's await never throws.
+   */
+  joinProjectGroup(projectId: string): Promise<void>;
+
+  /**
+   * Inverse of joinProjectGroup. Same error-handling contract.
+   */
+  leaveProjectGroup(projectId: string): Promise<void>;
+}
+```
+
+**Implementation sketch** (staff-engineer-level — developer writes the exact code):
+
+```typescript
+async joinProjectGroup(projectId: string): Promise<void> {
+  // Validate shape defensively — the backend throws HubException on
+  // non-Guid strings. Match by regex rather than round-tripping through
+  // the backend to avoid an avoidable error log.
+  if (!projectId || projectId.trim().length === 0) return;
+
+  const connection = this.connection;
+  if (!connection || this.state() !== 'connected') {
+    // Intentional no-op: the state-service effect on connectionState will
+    // call this method again when the connection lands in 'connected'.
+    return;
+  }
+
+  try {
+    await connection.invoke('JoinProjectGroup', projectId);
+  } catch {
+    console.error('SignalR JoinProjectGroup failed');
+  }
+}
+```
+
+`leaveProjectGroup` is symmetric. **Neither method ever logs the projectId or any payload** — per the CLAUDE.md logging/privacy rule and the AC "No payload field, no JWT, and no user id is written to console.log."
+
+### Event handlers — reconciliation rules
+
+All handlers are **idempotent** and **silent-no-op on missing entities**, per the AC "An event whose payload references an entity not currently present in local state is silently ignored."
+
+#### ProjectStateService
+
+```typescript
+// ProjectUpdated: replace-in-place by projectId. If absent, ignore (user
+// isn't a member locally).
+private onProjectUpdated(evt: ProjectUpdatedEvent): void {
+  const current = this.getState().projects;
+  const index = current.findIndex(p => p.id === evt.projectId);
+  if (index === -1) return; // silent no-op
+  const updated: ProjectSummary = {
+    ...current[index],
+    name: evt.name,
+    description: evt.description,
+    updatedAt: evt.updatedAt
+  };
+  const next = [
+    ...current.slice(0, index),
+    updated,
+    ...current.slice(index + 1)
+  ];
+  this.setState({ projects: next });
+}
+
+// ProjectDeleted: filter out. No-op if absent.
+private onProjectDeleted(evt: ProjectDeletedEvent): void {
+  const current = this.getState().projects;
+  const next = current.filter(p => p.id !== evt.projectId);
+  if (next.length !== current.length) {
+    this.setState({ projects: next });
+  }
+}
+```
+
+**Group-membership reconciliation (same service, separate effect):**
+
+```typescript
+// Run whenever projects list OR connection state changes. Only acts when
+// connected. Joins ids newly present, leaves ids newly absent.
+private joinedProjectIds = new Set<string>();
+
+constructor() {
+  super();
+  // …existing logout effect…
+
+  effect(() => {
+    if (this.signalRService.connectionState() !== 'connected') {
+      // Disconnect wipes server-side group membership; clear local tracking
+      // so a reconnect rejoins all current projects from scratch.
+      this.joinedProjectIds.clear();
+      return;
+    }
+    const desired = new Set(this.projects().map(p => p.id));
+    // join newly desired
+    for (const id of desired) {
+      if (!this.joinedProjectIds.has(id)) {
+        void this.signalRService.joinProjectGroup(id);
+        this.joinedProjectIds.add(id);
+      }
+    }
+    // leave no-longer-desired
+    for (const id of this.joinedProjectIds) {
+      if (!desired.has(id)) {
+        void this.signalRService.leaveProjectGroup(id);
+        this.joinedProjectIds.delete(id);
+      }
+    }
+  });
+}
+```
+
+#### MembersStateService
+
+```typescript
+// MemberRemoved: payload carries projectId. Filter out user from that
+// slice. No-op if slice missing or user absent.
+private onMemberRemoved(evt: MemberRemovedEvent): void {
+  const slice = this.getState().byProjectId[evt.projectId];
+  if (!slice) return;
+  const next = slice.members.filter(m => m.userId !== evt.userId);
+  if (next.length !== slice.members.length) {
+    this.upsertSlice(evt.projectId, { members: next });
+  }
+}
+
+// MemberAdded: ⚠ payload has NO projectId (see Known Backend Contract
+// Caveats). Attribution strategy: the most-recently-opened members dialog
+// sets `currentProjectContext` on MembersStateService; MemberAdded events
+// are appended to THAT slice only while the context is set. If no context,
+// the event is ignored (fall back to next dialog open triggering a reload).
+//
+// This is the best we can do until the backend wraps the payload in a
+// MemberAddedEventDto with projectId.
+private onMemberAdded(evt: MemberAddedEvent): void {
+  const projectId = this.currentProjectContext();
+  if (!projectId) return; // no open dialog → drop
+  const slice = this.getState().byProjectId[projectId];
+  if (!slice) return;
+  // Dedupe — if the user was just added locally via HTTP response, skip.
+  if (slice.members.some(m => m.userId === evt.userId)) return;
+  const newMember: MemberSummary = {
+    userId: evt.userId,
+    name: evt.name,
+    email: evt.email,
+    role: evt.role,
+    joinedAt: evt.joinedAt
+  };
+  this.upsertSlice(projectId, { members: [...slice.members, newMember] });
+}
+```
+
+**New public API on `MembersStateService`:**
+
+```typescript
+private readonly contextSignal = signal<string | null>(null);
+readonly currentProjectContext = this.contextSignal.asReadonly();
+
+/** Called by members-dialog.component.ts on open. */
+setCurrentProjectContext(projectId: string): void {
+  this.contextSignal.set(projectId);
+}
+
+/** Called by members-dialog.component.ts on close. */
+clearCurrentProjectContext(): void {
+  this.contextSignal.set(null);
+}
+```
+
+The existing `members-dialog.component.ts` is modified to call these two methods on open/close.
+
+#### BoardStateService
+
+```typescript
+// ColumnCreated: append if projectId matches current, else ignore.
+// Dedupe by id. Order by columnOrder.
+private onColumnCreated(evt: ColumnCreatedEvent): void {
+  if (evt.projectId !== this.getState().currentProjectId) return;
+  const current = this.getState().columns;
+  if (current.some(c => c.id === evt.id)) return;
+  const next = [...current, { …evt }].sort((a, b) => a.columnOrder - b.columnOrder);
+  this.setState({ columns: next });
+}
+
+// ColumnDeleted: remove column + drop its tasks bucket. No-op if absent.
+private onColumnDeleted(evt: ColumnDeletedEvent): void {
+  if (evt.projectId !== this.getState().currentProjectId) return;
+  const current = this.getState().columns;
+  const nextColumns = current.filter(c => c.id !== evt.columnId);
+  if (nextColumns.length === current.length) return;
+  const tasksByColumnId = { ...this.getState().tasksByColumnId };
+  delete tasksByColumnId[evt.columnId];
+  this.setState({ columns: nextColumns, tasksByColumnId });
+}
+
+// TaskCreated: append to the task bucket of evt.columnId, only if that
+// column belongs to the current board. No-op if column is unknown
+// (covers the "event for entity not in local state" AC).
+private onTaskCreated(evt: TaskCreatedEvent): void {
+  if (this.getState().currentProjectId === null) return;
+  const columns = this.getState().columns;
+  const column = columns.find(c => c.id === evt.columnId);
+  if (!column) return;
+  const bucket = this.getState().tasksByColumnId[evt.columnId] ?? [];
+  if (bucket.some(t => t.id === evt.id)) return;
+  const next = [...bucket, { …evt }].sort((a, b) => a.taskOrder - b.taskOrder);
+  this.setState({
+    tasksByColumnId: { ...this.getState().tasksByColumnId, [evt.columnId]: next }
+  });
+}
+
+// TaskMoved: remove from oldColumnId bucket, insert into newColumnId
+// bucket using evt.newTaskOrder. No-op if task is absent from local state.
+private onTaskMoved(evt: TaskMovedEvent): void {
+  if (this.getState().currentProjectId === null) return;
+  const buckets = this.getState().tasksByColumnId;
+  const oldBucket = buckets[evt.oldColumnId] ?? [];
+  const existsOld = oldBucket.some(t => t.id === evt.taskId);
+  if (!existsOld) return; // task not in state → silent no-op
+  const newOldBucket = oldBucket.filter(t => t.id !== evt.taskId);
+  const newBucket = buckets[evt.newColumnId] ?? [];
+  const movedTask: BoardTask = { …evt.task };
+  // insert ordered
+  const inserted = [...newBucket.filter(t => t.id !== movedTask.id), movedTask]
+    .sort((a, b) => a.taskOrder - b.taskOrder);
+  this.setState({
+    tasksByColumnId: {
+      ...buckets,
+      [evt.oldColumnId]: newOldBucket,
+      [evt.newColumnId]: inserted
+    }
+  });
+}
+```
+
+#### BoardStateService — board lifecycle API
+
+```typescript
+/**
+ * Called by BoardPageComponent.ngOnInit with the :projectId param.
+ * Sets currentProjectId, clears columns/tasks from any prior board,
+ * and invokes JoinProjectGroup.
+ */
+enterBoard(projectId: string): void {
+  this.setState({
+    currentProjectId: projectId,
+    columns: [],
+    tasksByColumnId: {}
+  });
+  void this.signalRService.joinProjectGroup(projectId);
+}
+
+/**
+ * Called by BoardPageComponent.ngOnDestroy. Clears the currentProjectId
+ * and invokes LeaveProjectGroup ONLY IF the project is no longer in the
+ * user's list (see Layer-2 Leave semantics in the Join strategy section).
+ */
+leaveBoard(): void {
+  const projectId = this.getState().currentProjectId;
+  this.setState({ currentProjectId: null, columns: [], tasksByColumnId: {} });
+  if (!projectId) return;
+  const userProjects = this.projectStateService.projects();
+  const stillAMember = userProjects.some(p => p.id === projectId);
+  if (!stillAMember) {
+    void this.signalRService.leaveProjectGroup(projectId);
+  }
+}
+```
+
+### BoardPageComponent — modified
+
+**Signature:**
+
+```typescript
+@Component({
+  selector: 'app-board-page',
+  imports: [],
+  templateUrl: './board-page.component.html',
+  styleUrl: './board-page.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class BoardPageComponent implements OnInit, OnDestroy {
+  private readonly route = inject(ActivatedRoute);
+  private readonly boardState = inject(BoardStateService);
+
+  ngOnInit(): void {
+    const projectId = this.route.snapshot.paramMap.get('projectId');
+    if (!projectId) return; // shouldn't happen given the route shape
+    this.boardState.enterBoard(projectId);
+  }
+
+  ngOnDestroy(): void {
+    this.boardState.leaveBoard();
+  }
+}
+```
+
+The template (`board-page.component.html`) is NOT changed in this ticket — it stays the placeholder shell. Board UI is #47.
+
+### HTTP Contracts — unchanged
+
+No new HTTP endpoints. This ticket consumes only SignalR events. Existing HTTP behavior in `ProjectsApiService` / `MembersApiService` is unchanged.
+
+---
+
+## Implementation Steps
+
+Follow in order. Run `npm run build` and `npm run test -- --watch=false` after step 5 and after step 11.
+
+### 1. Realtime event DTOs
+- [ ] Create `src/app/core/models/realtime-events.ts` with all interfaces and the `REALTIME_EVENT` constants object from the [State & Data Layer](#state--data-layer) section.
+
+### 2. Extend SignalRService
+- [ ] Add `joinProjectGroup(projectId: string): Promise<void>` and `leaveProjectGroup(projectId: string): Promise<void>` to `SignalRServiceContract`.
+- [ ] Implement both methods on `SignalRService`. Guard on `state() !== 'connected'` → no-op. Wrap `connection.invoke(...)` in try/catch; log via `console.error` only (no payload).
+- [ ] **Add unit tests** in `signalr.service.spec.ts`:
+  - invokes underlying `connection.invoke('JoinProjectGroup', id)` when connected
+  - is a no-op (does NOT invoke) when disconnected
+  - logs via console.error on invoke rejection; never logs `id`
+  - same for `leaveProjectGroup`
+
+### 3. BoardStateService scaffolding
+- [ ] Create `src/app/features/board/state/board-state.model.ts`.
+- [ ] Create `src/app/features/board/state/board-state.service.ts` extending `BaseStateService<BoardState>`. Inject `SignalRService` and `ProjectStateService`.
+- [ ] Implement the `connectionState` effect that (re)subscribes to the four board events. Store subscriptions in a bag; tear down on re-run.
+- [ ] Implement `enterBoard(projectId)` and `leaveBoard()` per the [Board lifecycle API](#boardstateservice--board-lifecycle-api).
+- [ ] Expose public selectors: `currentProjectId`, `columns`, `tasksByColumnId`.
+
+### 4. ProjectStateService — add realtime subscribers + auto-join effect
+- [ ] Inject `SignalRService` (a new private field). `AuthService`, `ProjectsApiService` are already injected.
+- [ ] Add a `connectionState` effect that (re)subscribes to `ProjectUpdated` and `ProjectDeleted`. Reconcile per [Event handlers](#projectstateservice).
+- [ ] Add a second effect that diffs `this.projects()` against a private `joinedProjectIds: Set<string>` and invokes `joinProjectGroup` / `leaveProjectGroup` as described in [Join strategy](#join-strategy-two-layers). Clears the set on disconnect.
+- [ ] **Do NOT** change any existing HTTP flow — just layer realtime on top.
+
+### 5. MembersStateService — add realtime subscribers + dialog context
+- [ ] Inject `SignalRService`.
+- [ ] Add private `contextSignal = signal<string | null>(null)` and public `setCurrentProjectContext` / `clearCurrentProjectContext` / `currentProjectContext` readonly signal.
+- [ ] Add `connectionState` effect that (re)subscribes to `MemberAdded` and `MemberRemoved`. Reconcile per [Event handlers](#membersstateservice).
+- [ ] Build verify: `npm run build`. Expected: no compile errors.
+
+### 6. Wire up MembersDialog context
+- [ ] In `members-dialog.component.ts`: on component init / dialog open, call `membersStateService.setCurrentProjectContext(projectId)`. On destroy / dialog close, call `clearCurrentProjectContext()`. Use `DestroyRef` pattern already present in that file.
+- [ ] Verify no regression in the dialog's existing CRUD flows.
+
+### 7. Route update
+- [ ] In `app.routes.ts`: replace `path: 'board'` with `path: 'board/:projectId'`. Keep the loader and guard.
+- [ ] Search the codebase for hardcoded `'/board'` strings (router.navigate, routerLink, tests) and convert to `'/board/{id}'`. The grep already surfaced `app.routes.spec.ts` — update every `await router.navigate(['/board'])` to `await router.navigate(['/board/some-id'])`.
+- [ ] Update `app.routes.spec.ts` to still validate guard behavior against the parameterized path.
+
+### 8. BoardPageComponent wiring
+- [ ] Inject `ActivatedRoute` and `BoardStateService`.
+- [ ] Implement `ngOnInit` and `ngOnDestroy` per spec.
+- [ ] Update `board-page.component.spec.ts`:
+  - existing rendering tests still pass (template is untouched)
+  - new test: `ngOnInit` with `paramMap.projectId = 'p-1'` calls `boardState.enterBoard('p-1')`
+  - new test: `ngOnDestroy` calls `boardState.leaveBoard()`
+  - provide `ActivatedRoute` mock with `snapshot.paramMap.get('projectId')` returning `'p-1'`; provide `BoardStateService` with spy methods
+
+### 9. Project-card navigation (conditional)
+- [ ] Open `features/projects/components/project-card/project-card.component.ts` and its template. If it navigates to `/board` on click, update to `/board/${project.id}` (routerLink or router.navigate). If it doesn't yet navigate to a board, leave it — the dashboard→board navigation path is likely a future ticket.
+
+### 10. Realtime tests for state services
+- [ ] Add a `describe('real-time events', ...)` block in `project-state.service.spec.ts`:
+  - provide mock `SignalRService` with `connectionState` a `WritableSignal<SignalRConnectionState>` under test control, and `on<T>(name)` returning a `Subject<T>` the test can `.next(...)` into
+  - test that emitting `ProjectUpdated` replaces the matching entry
+  - test that emitting `ProjectDeleted` removes the matching entry
+  - test no-op on absent id (no state change, no throw)
+  - test auto-join: when `projects()` becomes non-empty and state transitions to `'connected'`, `joinProjectGroup(id)` is invoked once per project id
+  - test auto-leave: when a project is removed from the list, `leaveProjectGroup(id)` is invoked
+  - test reconnect: on `connected → reconnecting → connected`, subscribers resubscribe and `joinedProjectIds` re-hydrates
+- [ ] Add a `describe('real-time events', ...)` block in `members-state.service.spec.ts`:
+  - MemberRemoved removes user from the matching slice; no-op if slice missing
+  - MemberAdded with context set appends; without context drops; duplicate user ignored
+- [ ] Add `board-state.service.spec.ts`:
+  - `enterBoard(projectId)` invokes `joinProjectGroup(projectId)` and sets `currentProjectId`
+  - `leaveBoard()` invokes `leaveProjectGroup` only when the project is no longer in user's list
+  - ColumnCreated appends when projectId matches; ignored when projectId differs
+  - ColumnDeleted removes matching column; no-op if absent
+  - TaskCreated appends to correct bucket; no-op when column is unknown
+  - TaskMoved removes from oldColumnId, inserts into newColumnId; no-op if task unknown in local state (this is the "ignored if not in state" AC)
+  - Each handler never throws given malformed/partial input (iterate malformed fixtures)
+  - No `console.log`/`console.error` calls contain payload fields (spy on console, fail if `.toHaveBeenCalledWith(stringContaining(projectId))`)
+
+### 11. Build + test verification
+- [ ] `npm run build` — must exit 0.
+- [ ] `npm run test -- --watch=false` — classify any failures as PRE-EXISTING or INTRODUCED per CLAUDE.md. Fix all INTRODUCED.
+- [ ] Manually verify in DevTools: log in, open the dashboard, check the WebSocket frames panel for a burst of `{"type":1,"target":"JoinProjectGroup","arguments":["<id>"]}` frames — one per project. Navigate to a board — one more Join frame for that id. Navigate back — no Leave frame (because user is still a member). Delete the project via API → Leave frame fires.
+
+**Performance considerations:**
+- The connection-state effect runs on every `connectionState` change; re-subscription overhead is O(event-count) = 4–8 subjects. Negligible.
+- The project-diff effect runs on every `projects()` change. Uses `Set` lookups — O(n).
+- TaskMoved reconciliation sorts a bucket — O(n log n) per move, n = tasks in a column. Fine for realistic boards.
+- No virtual scrolling needed in this ticket — no UI.
+
+---
+
+## QA Guidance
+
+### Test Strategy
+
+**Unit Tests (services):**
+- Every state service has a realtime describe-block using a mock `SignalRService` with test-controlled `Subject`s and a `WritableSignal<SignalRConnectionState>`. This lets each test drive connection-state transitions and emit events deterministically.
+- `SignalRService` itself gets two new tests for the hub invocations — using a mock `HubConnection`.
+
+**Integration Tests (component):**
+- `BoardPageComponent.ngOnInit` with a fake `ActivatedRoute.paramMap` → verifies `BoardStateService.enterBoard(id)` is called once.
+- Same for `ngOnDestroy` → `leaveBoard()`.
+
+**End-to-End (manual, per the AC):**
+- Two browser tabs, same user.
+- Tab A: dashboard. Tab B: dashboard. In A, rename a project via the edit dialog → B's card reflects the new name within 2s, no refresh.
+- In A, delete the project → B's card disappears within 2s.
+- Navigate B to `/board/<projectId>`. Capture WebSocket frames; expect one `JoinProjectGroup` frame with that id.
+- Navigate B back to `/dashboard`. With the project still present in B's list, expect NO `LeaveProjectGroup` frame (per the documented Leave semantics).
+- Manually POST a task/column to that project via the backend API (curl / Postman) → verify the event is received in B's DevTools Network frames.
+
+### Mocking Template
+
+```typescript
+// Shared helper for realtime tests
+import { Subject } from 'rxjs';
+import { signal, WritableSignal } from '@angular/core';
+
+export function createMockSignalRService() {
+  const subjects = new Map<string, Subject<any>>();
+  const connectionState: WritableSignal<'disconnected' | 'connecting' | 'connected' | 'reconnecting'> =
+    signal('disconnected');
+  return {
+    connectionState,
+    on: <T>(name: string) => {
+      let subject = subjects.get(name);
+      if (!subject) {
+        subject = new Subject();
+        subjects.set(name, subject);
+      }
+      return (subject as Subject<T>).asObservable();
+    },
+    emit: <T>(name: string, payload: T) => subjects.get(name)?.next(payload),
+    joinProjectGroup: jasmine.createSpy('joinProjectGroup'),
+    leaveProjectGroup: jasmine.createSpy('leaveProjectGroup'),
+    start: () => Promise.resolve(),
+    stop: () => Promise.resolve()
+  };
+}
+
+// Usage in TestBed:
+TestBed.configureTestingModule({
+  providers: [
+    ProjectStateService,
+    { provide: SignalRService, useValue: createMockSignalRService() },
+    // …other providers
+  ]
+});
+```
+
+### Edge Cases to Test
+- Event arrives BEFORE connection reaches `'connected'` — no-op, no throw (Subject is buffered only if state service hasn't subscribed yet; if already subscribed after a prior connect cycle, it lands correctly).
+- Event with unknown id — silent no-op.
+- TaskMoved with task not in state — silent no-op (covered in AC).
+- MemberAdded without dialog context — dropped silently (documented behavior).
+- Logout while board is open — `AuthStateService` flips, `SignalRService.stop()` runs, all state-service subjects complete; board's `leaveBoard` on destroy runs but is a no-op because connection is down.
+- Reconnect during board session — `connectionState` flips `connected → reconnecting → connected`; each state service re-subscribes; `ProjectStateService` re-joins all projects; board's Layer-2 join is NOT automatically re-issued (it was a one-shot at enterBoard). **Decision:** `BoardStateService` also re-joins its `currentProjectId` on `connectionState → connected` transition (if `currentProjectId !== null`) to survive reconnects.
+- Two sessions in two tabs, same user, same board — both receive the same events. Reconciliation is idempotent by id, so concurrent state updates converge.
+- A malformed payload (e.g., missing `projectId`) — handler type-guards; else silent no-op.
+
+### Console Hygiene Verification
+- Jasmine `spyOn(console, 'error')` and `spyOn(console, 'log')` in every new describe-block.
+- Assert that no payload field (projectId, userId, email, token) is ever part of a logged string. Use `expect(console.error).not.toHaveBeenCalledWith(jasmine.stringContaining(projectId))` pattern.
+
+---
+
+## Known Backend Contract Caveats
+
+Documented so QA and future work know where the edges are.
+
+1. **`MemberAdded` payload lacks `projectId`.** The payload is the raw `MemberResponseDto` — see `backend_api_map.md` §"Server-sent events." This frontend ticket works around it by attributing `MemberAdded` events to the currently-open members dialog (see [`onMemberAdded`](#membersstateservice)). This is correct for the AC (which only requires the reconciliation while the dialog is open) but will drop events if no dialog is open.
+   **Recommendation:** file a backend ticket to wrap the payload in a `MemberAddedEventDto { projectId, member: MemberResponseDto }` so attribution is unambiguous. Once that lands, the attribution logic collapses to the same pattern as `MemberRemoved`.
+
+2. **`TaskCreated` and `TaskMoved` payloads lack `projectId`.** Attribution is done via the `currentProjectId` held by `BoardStateService` plus the fact that the client only receives these events on project groups it has joined. This is safe because: (a) we only enter `enterBoard(id)` when the URL's `:projectId` equals `id`, so `currentProjectId` is accurate; (b) backend broadcasts only to the joined group, so an event arriving while on board X is for project X.
+
+3. **`ProjectCreated` is not broadcast by design** (see `backend_api_map.md` §"Not yet broadcast"). This ticket does NOT subscribe to a `ProjectCreated` event name. Users see newly created projects only on the next `loadProjects()` (which the creator triggers via their own HTTP response handling — unchanged by this ticket).
+
+4. **`LeaveProjectGroup` on board exit — AC literal vs. behavior:** The AC states `LeaveProjectGroup` is invoked on board exit. In the chosen design, Leave is **suppressed** when the user is still a member of that project (Layer 1 still wants the group). If QA's reading of the AC is strict-literal, escalate to re-evaluate.
+
+---
+
+## Design Validation (Staff-Engineer Self-Check)
+
+- [x] Interfaces align with backend DTOs (camelCase, nullable fields preserved, ISO-8601 dates typed as `string`).
+- [x] `inject()` is used throughout — matches existing pattern.
+- [x] Signals for UI state; RxJS for event streams; `effect()` for connection-state + project-list reconciliation.
+- [x] `ChangeDetectionStrategy.OnPush` preserved on `BoardPageComponent`.
+- [x] Route guard (`authGuard`) retained on the parameterized board path.
+- [x] No payload fields logged anywhere.
+- [x] Every new subscriber re-registers on `connectionState === 'connected'` — survives logout/login.
+- [x] All reconciliation handlers are idempotent and silent-no-op on missing entities — satisfies the "ignored if not in local state" AC.
+- [x] All new files listed; all modifications listed.
+- [x] Implementation steps ordered: DTOs → transport extension → services → component wiring → route → tests → build.
+- [x] Acceptance criteria mapped:
+  - AC 1 (ProjectUpdated dashboard) → `ProjectStateService.onProjectUpdated` + Layer-1 auto-join
+  - AC 2 (ProjectDeleted dashboard) → `ProjectStateService.onProjectDeleted`
+  - AC 3 (MemberAdded dialog) → `MembersStateService.onMemberAdded` + dialog context
+  - AC 4 (MemberRemoved dialog) → `MembersStateService.onMemberRemoved`
+  - AC 5 (Join on board, Leave on exit) → `BoardStateService.enterBoard` / `leaveBoard`
+  - AC 6 (TaskMoved) → `BoardStateService.onTaskMoved`
+  - AC 7 (TaskCreated) → `BoardStateService.onTaskCreated`
+  - AC 8 (ColumnCreated) → `BoardStateService.onColumnCreated`
+  - AC 9 (ColumnDeleted) → `BoardStateService.onColumnDeleted`
+  - AC 10 (unjoined events ignored) → group-filter at backend + `currentProjectId` guard in handlers
+  - AC 11 (entity-not-in-state ignored) → each handler's absence-check
+  - AC 12 (subscriptions torn down on logout) → `SignalRService.stop()` contract + subscription bag teardown
+  - AC 13 (no payload logged) → try/catch with bare-message logs only; verified by spec
+  - AC 14 (build succeeds) → implementation step 11
+  - AC 15 (tests pass) → implementation step 11
+
+---
+
+## Development Status
+
+**Implemented** — 2026-05-04
+
+### Files created
+- `KanbAI-Web/src/app/core/models/realtime-events.ts` — typed DTOs + `REALTIME_EVENT` name constants
+- `KanbAI-Web/src/app/features/board/state/board-state.model.ts`
+- `KanbAI-Web/src/app/features/board/state/board-state.service.ts`
+- `KanbAI-Web/src/app/features/board/state/board-state.service.spec.ts`
+
+### Files modified
+- `KanbAI-Web/src/app/core/services/signalr.service.ts` — added `joinProjectGroup` / `leaveProjectGroup` (extended `SignalRServiceContract`)
+- `KanbAI-Web/src/app/core/services/signalr.service.spec.ts` — added `invoke` to the mock HubConnection + 5 tests for the new methods (connected, disconnected, empty id, error logging/privacy)
+- `KanbAI-Web/src/app/app.routes.ts` — replaced `path: 'board'` with `path: 'board/:projectId'`
+- `KanbAI-Web/src/app/app.routes.spec.ts` — migrated every `/board` navigation / returnUrl assertion to `/board/proj-1`
+- `KanbAI-Web/src/app/core/constants/auth-routes.ts` — `PROTECTED_PATHS` now carries `'board/:projectId'` instead of `'board'`
+- `KanbAI-Web/src/app/core/constants/auth-routes.spec.ts` — updated the "board in PROTECTED_PATHS" lock test to the new path
+- `KanbAI-Web/src/app/features/projects/state/project-state.service.ts` — injected `SignalRService`; added real-time subscribers (via connection-state effect) + Layer-1 auto-join/leave effect
+- `KanbAI-Web/src/app/features/projects/state/project-state.service.spec.ts` — added `SignalRService` mock to DI + a `real-time events` describe covering `ProjectUpdated` / `ProjectDeleted` / auto-join / auto-leave / reconnect re-subscription / console hygiene
+- `KanbAI-Web/src/app/features/projects/state/members-state.service.ts` — injected `SignalRService`; added realtime subscribers, `currentProjectContext` signal + `setCurrentProjectContext` / `clearCurrentProjectContext`
+- `KanbAI-Web/src/app/features/projects/state/members-state.service.spec.ts` — added `SignalRService` mock + a `real-time events` describe covering `MemberRemoved` / `MemberAdded` (with and without context) / console hygiene
+- `KanbAI-Web/src/app/features/projects/components/members-dialog/members-dialog.component.ts` — calls `setCurrentProjectContext` on init and clears it on destroy
+- `KanbAI-Web/src/app/features/projects/components/members-dialog/members-dialog.component.spec.ts` — extended the mock members-state to include the two context methods + 2 new assertions (set on init, clear on destroy)
+- `KanbAI-Web/src/app/features/board/board-page/board-page.component.ts` — implements `OnInit` / `OnDestroy`, reads `projectId` from `ActivatedRoute.snapshot.paramMap`, drives `BoardStateService.enterBoard` / `leaveBoard`
+- `KanbAI-Web/src/app/features/board/board-page/board-page.component.spec.ts` — rewritten to mount with mock `ActivatedRoute` + `BoardStateService`; new tests for `ngOnInit` / `ngOnDestroy` / missing-param guard + kept the rendering tests
+
+### Build
+- `npm run build` — **PASS** (clean bundle, no TS errors, no warnings).
+
+### Tests
+- `npm run test -- --watch=false` — **684 passed / 0 failed** on the happy full-suite run.
+- Total test files: 42 (one new: `board-state.service.spec.ts`, ~30 tests).
+- **PRE-EXISTING flakiness** in `src/app/core/services/signalr.service.spec.ts`: the `vi.mock('@microsoft/signalr', …)` factory occasionally loses its race with Angular's `vitest-mock-patch` when the full suite is run, manifesting either as the whole file failing to load (0 tests ran in that file) or as 17 of its tests failing with `TypeError: Cannot read properties of null (reading '_connection')` / `TypeError: Cannot read properties of undefined (reading 'trim')`. **Verified pre-existing by stashing my changes and observing the same intermittent failure on the base commit** (3 runs on base: 2× all-pass, 1× file failed). The file's own top-of-file comment documents this race. This ticket does not touch the underlying mock plumbing — the failure is not introduced by #46.
+- No INTRODUCED failures. All realtime tests (ProjectStateService / MembersStateService / BoardStateService / MembersDialogComponent / BoardPageComponent / signalr.service additions / auth-routes) pass deterministically.
+
+### Edge cases handled per tech spec
+- Reconnect during board session: `BoardStateService` re-issues `JoinProjectGroup(currentProjectId)` on every `connectionState → connected` transition (see effect in `board-state.service.ts`).
+- Logout → login cycle: every realtime subscriber (projects / members / board) lives in a `subscriptionBag` torn down on non-connected transitions and re-created on `connected`, so post-logout logins re-wire to the fresh Subjects minted by `SignalRService.on(...)`.
+- `MemberAdded` without dialog context: silently dropped (documented caveat until backend wraps payload).
+- `TaskMoved` / `TaskCreated` for a task or column not in state: silent no-op (AC11).
+- `LeaveProjectGroup` on board exit suppressed when the user is still a member of the project (tech spec §"AC literal vs. user-correct behavior" decision).
+- Malformed payloads (null, missing `projectId`, etc.): each handler type-guards; no throws. Covered by the `Malformed / partial payloads` describe in `board-state.service.spec.ts`.
+- Console hygiene: every new handler tested to ensure no `projectId` / `userId` / `email` appears in `console.log` or `console.error`.
+
+### Known limitations / follow-ups
+- `BoardPageComponent` remains a visual placeholder per tech spec — the UI binding to `BoardStateService.columns` / `tasksByColumnId` lands in #47.
+- Neither the column list nor the task buckets are populated via HTTP in this ticket (explicitly out of scope). Events reconcile against empty state by default, so in current production builds only the Join/Leave lifecycle + subscribers are visibly exercised until the `HTTP load columns + tasks` story lands.
+- The `MemberAdded` payload attribution through `currentProjectContext` is a documented workaround; once the backend wraps the payload in a `MemberAddedEventDto { projectId, member }`, `onMemberAdded` should be collapsed to mirror `onMemberRemoved`.
+
+### Decisions made outside the spec
+- **PROTECTED_PATHS constant**: the spec lists the `app.routes.spec.ts` migration, but the `auth-routes.spec.ts` file separately locks the `'board'` entry in `PROTECTED_PATHS`. Updated both `auth-routes.ts` (value → `'board/:projectId'`) and its lock-test in the same spirit as the spec's route rename so the `routes.find(r => r.path === p)` sweep keeps guard coverage on the new path. No semantic change for callers.
+- **Signal-type for `currentProjectContext`**: exposed as `Signal<string | null>` (via `contextSignal.asReadonly()`) so consumers can `computed()` over it; the spec only required the two setter methods and never nailed down reader access. Chose the readonly-signal idiom already used for `projects` / `hasLoaded` / etc. in the same file.
+
+---
+
+*"Development is complete and files are saved. You can now instruct QA to review the implementation and write automated tests."*
+
+---
+
+## QA Review — 2026-05-04
+
+### AC coverage
+
+| AC | Status | Spec file | Test name(s) |
+|----|--------|-----------|--------------|
+| AC1 ProjectUpdated on dashboard | covered | `KanbAI-Web/src/app/features/projects/state/project-state.service.spec.ts` | `real-time events > ProjectUpdated > replaces the matching entry in place on event arrival` (observable: `service.projects()[0].name` delta asserted) |
+| AC2 ProjectDeleted on dashboard | covered | `project-state.service.spec.ts` | `real-time events > ProjectDeleted > removes the matching entry on event arrival` |
+| AC3 MemberAdded in dialog | covered | `KanbAI-Web/src/app/features/projects/state/members-state.service.spec.ts` | `real-time events > MemberAdded > appends when context is set to the matching project`; MembersDialogComponent integration: `members-dialog.component.spec.ts > sets the members-state realtime context to the open project id on init` |
+| AC4 MemberRemoved in dialog | covered | `members-state.service.spec.ts` | `real-time events > MemberRemoved > removes the user from the matching slice on event arrival` |
+| AC5 Join on board enter / conditional Leave on exit (AC-literal deviation) | covered | `KanbAI-Web/src/app/features/board/state/board-state.service.spec.ts` | `enterBoard() / leaveBoard() > enterBoard sets currentProjectId and invokes joinProjectGroup`; `leaveBoard does NOT invoke leaveProjectGroup when user is still a member` (suppression); `leaveBoard invokes leaveProjectGroup when user is no longer a member`; `leaveBoard is a harmless no-op when currentProjectId is already null` |
+| AC6 TaskMoved | covered | `board-state.service.spec.ts` | `TaskMoved > removes from oldColumnId and inserts into newColumnId`; `is a silent no-op when the task is not in local state` (the "ignored if not in state" half) |
+| AC7 TaskCreated | covered | `board-state.service.spec.ts` | `TaskCreated > appends to the matching bucket in taskOrder ascending`; `is a silent no-op when the target column is unknown`; `dedupes a TaskCreated whose id is already in the bucket` |
+| AC8 ColumnCreated | covered | `board-state.service.spec.ts` | `ColumnCreated > appends when projectId matches the current board`; `maintains columnOrder ascending across multiple emits`; `dedupes a ColumnCreated with an id already in state` |
+| AC9 ColumnDeleted | covered | `board-state.service.spec.ts` | `ColumnDeleted > removes the column and drops its tasks bucket`; `is a silent no-op when the column is absent` |
+| AC10 Events for unjoined projects ignored | covered | `board-state.service.spec.ts` | `ColumnCreated > ignores a ColumnCreated for a different project`; `ColumnDeleted > ignores a ColumnDeleted for a different project`; plus Layer-1 auto-join proof in `project-state.service.spec.ts > auto Join / Leave group membership (Layer 1)` |
+| AC11 Entity not in local state → silent no-op | covered | `board-state.service.spec.ts` (TaskMoved/TaskCreated/ColumnDeleted no-op tests, `Malformed / partial payloads`); `project-state.service.spec.ts` (`ProjectUpdated is a silent no-op when the project is not in local state`; `ProjectDeleted is a silent no-op when the project is already absent`); `members-state.service.spec.ts` (MemberRemoved `is a silent no-op when the slice is missing`, `is a silent no-op when the user is not in the slice`) | see left |
+| AC12 Subscriptions torn down on logout | covered | `project-state.service.spec.ts > real-time events > re-subscription after logout → login cycle`; `project-state.service.spec.ts > Subscription teardown on disconnect` (ADDED); `members-state.service.spec.ts > Subscription teardown on disconnect` (ADDED); `board-state.service.spec.ts > Logout → login cycle` (ADDED) | see left — the existing `re-subscription` test validates that fresh Subjects are wired after stop()/start(); the ADDED describe blocks cover the defense-in-depth angle for each service |
+| AC13 No payload logged | covered | `project-state.service.spec.ts > real-time events > Console hygiene`; `members-state.service.spec.ts > real-time events > Console hygiene`; `board-state.service.spec.ts > Console hygiene`; `signalr.service.spec.ts > joinProjectGroup() / leaveProjectGroup() > logs a bare error and never throws when the hub invoke rejects, and never logs the projectId` | see left |
+| AC14 Build succeeds | covered | `npm run build` exit 0 | N/A |
+| AC15 Tests pass | covered | `npm run test -- --watch=false` | 688 passed / 0 failed |
+
+### Gaps found & gaps filled
+
+Four gap-filler tests were added. All production code is untouched; no new spec files were created.
+
+1. **BoardStateService reconnect with no active board — Join must NOT fire.** The tech spec §"Edge Cases" gates the reconnect Join on `currentProjectId !== null`, but the existing spec only asserted the positive path. **Added:** `board-state.service.spec.ts > Reconnect — re-issues board-scope Join > does NOT re-issue a Join on reconnect when no board is active (currentProjectId === null)`.
+2. **BoardStateService post-stop()/start() re-subscription (AC12).** The `ProjectStateService` spec had an explicit `re-subscription after logout → login cycle` test; the `BoardStateService` spec did not. **Added:** `board-state.service.spec.ts > Logout → login cycle (AC12 — subscribers re-wire to fresh Subjects) > a ColumnCreated emitted on a FRESH Subject after a stop()/start() cycle still reconciles`.
+3. **ProjectStateService — disconnect tears down subscribers.** Production code explicitly calls `teardownRealtimeSubscriptions()` when `state !== 'connected'`; the spec did not lock that behavior. **Added:** `project-state.service.spec.ts > real-time events > Subscription teardown on disconnect (AC12 defense in depth) > stops reconciling ProjectUpdated after connectionState leaves connected`.
+4. **MembersStateService — disconnect tears down subscribers.** Same rationale. **Added:** `members-state.service.spec.ts > real-time events > Subscription teardown on disconnect (AC12 defense in depth) > stops reconciling MemberRemoved after connectionState leaves connected`.
+
+### Final test counts
+
+- Before: 42 files, **684 passed / 0 failed / 0 skipped**
+- After: 42 files, **688 passed / 0 failed / 0 skipped**
+- Delta: **+4 tests**, 0 files added, 0 production files touched.
+- Build: `npm run build` exits 0, bundle generated cleanly, no warnings.
+
+### Bugs / concerns flagged
+
+- **Inconsistency (not a bug at current design):** `BoardStateService`'s connection-state effect does NOT proactively call `teardownSubscriptions()` on transition to non-`'connected'` states (early-return without teardown). `ProjectStateService` and `MembersStateService` DO. Under the current contract this is fine — `SignalRService.stop()` completes every event Subject so stale subscriptions are inert — and on the next 'connected' transition `BoardStateService` does call `teardownSubscriptions()` as part of the refresh step. The `board-state.service.spec.ts > Logout → login cycle` test I added validates the contract end-to-end (subjects cleared → fresh subject after reconnect → event reconciled). No code change recommended in this ticket, but worth a note in #47's scope review if event plumbing is refactored.
+- **Console hygiene verified:** the three handler specs (ProjectStateService / MembersStateService / BoardStateService) each include a `Console hygiene` describe that spies `console.log` + `console.error`, emits events with sentinel ids/emails, and asserts no spy call's stringified args contain any sentinel substring. The `SignalRService` Privacy test additionally covers the invoke-rejection path.
+- **PRE-EXISTING flake confirmed absent on this run:** the documented `signalr.service.spec.ts` `vi.mock('@microsoft/signalr', …)` race did not manifest on the post-change happy-path run; all 23 tests in that file passed. If it reappears in CI, it is PRE-EXISTING per the tech spec §"Development Status" note and the top-of-file comment in `signalr.service.spec.ts`.
+- **No INTRODUCED failures.** The four added tests all pass; no previously-passing test regressed.
+
+### Console-hygiene verdict
+
+**Pass.** Every new real-time handler is covered by a `Console hygiene` describe block that spies both sinks, emits events with sentinel `projectId` / `userId` / `email` / column / task values, and asserts every logged argument's stringified form does NOT contain any sentinel substring. The `SignalRService` group-invoke privacy test additionally covers the `HubException` branch (rejected invoke whose message contains the `projectId`). No `projectId`, `userId`, `email`, or token appears in any `console.error` or `console.log` call exercised by the new handlers.
+
+### Final verdict
+
+**Ready for code review.** All 15 acceptance criteria are covered by deterministic automated tests asserting observable behavior (state deltas on `projects()`, `members`, `columns`, `tasksByColumnId`; spy-call shape on `joinProjectGroup` / `leaveProjectGroup`). Coverage targets are met for the AC surface. Build exits 0. 688/688 tests pass. One design-consistency note flagged (BoardStateService teardown-on-disconnect asymmetry) is explicitly NOT a bug under the current contract; attaching it to #47's scope review is sufficient.
+
+*"Test suite complete. All acceptance criteria covered, coverage targets met, and tests passing. Feature is ready for manual QA and code review."*


### PR DESCRIPTION
This commit closes the loop on real-time collaboration by wiring the SignalR client to the Angular Signals-based state services. It enables automatic UI updates for project, member, column, and task changes without requiring manual page refreshes.

Key changes include:
- Introduced new `realtime-events.ts` to define all server-sent event DTOs.
- Extended `SignalRService` with `joinProjectGroup` and `leaveProjectGroup` hub methods.
- Created `BoardStateService` to manage board-specific state and reconcile column/task events.
- Updated `ProjectStateService` and `MembersStateService` to subscribe to project- and member-related events.
- Implemented a two-layer strategy for SignalR group membership, including auto-joining all user's projects and explicit join/leave for the active board.
- The board route (`/board`) is now parameterized (`/board/:projectId`) to support board-specific event subscriptions.

This delivers the user-visible real-time behavior for issue #46 and unblocks dependent features like optimistic UI updates in #47.